### PR TITLE
Add "downloadURL" key in AltStore.json to make it work courrectly with SideStore

### DIFF
--- a/AltStore.json
+++ b/AltStore.json
@@ -30,6 +30,7 @@
         "https://github.com/EhPanda-Team/ehpanda-website/raw/main/public/img/screenshot/Setting_EN_Light.png",
         "https://github.com/EhPanda-Team/ehpanda-website/raw/main/public/img/screenshot/DomainFronting_EN_Light.png"
       ],
+      "downloadURL": "https://github.com/EhPanda-Team/EhPanda/releases/download/v2.7.4/EhPanda.ipa"
       "versions": [
         {
           "version": "2.7.4",

--- a/AltStore.json
+++ b/AltStore.json
@@ -30,7 +30,7 @@
         "https://github.com/EhPanda-Team/ehpanda-website/raw/main/public/img/screenshot/Setting_EN_Light.png",
         "https://github.com/EhPanda-Team/ehpanda-website/raw/main/public/img/screenshot/DomainFronting_EN_Light.png"
       ],
-      "downloadURL": "https://github.com/EhPanda-Team/EhPanda/releases/download/v2.7.4/EhPanda.ipa"
+      "downloadURL": "https://github.com/EhPanda-Team/EhPanda/releases/latest/download/EhPanda.ipa",
       "versions": [
         {
           "version": "2.7.4",


### PR DESCRIPTION
SideStore app sources is a bit [different](https://wiki.sidestore.io/advanced/app-sources/#deprecated-versions-api) from AltStore's.
The modified file is tested compatible with AltStore by using [AltSource Browse](https://altsource.by.lao.sb/browse/)