### PR TITLE
Fix TCA Warnings

### DIFF
--- a/EhPanda/App/Tools/Clients/AppDelegateClient.swift
+++ b/EhPanda/App/Tools/Clients/AppDelegateClient.swift
@@ -9,8 +9,8 @@ import SwiftUI
 import ComposableArchitecture
 
 struct AppDelegateClient {
-    let setOrientation: (UIInterfaceOrientationMask) -> EffectTask<Never>
-    let setOrientationMask: (UIInterfaceOrientationMask) -> EffectTask<Never>
+    let setOrientation: (UIInterfaceOrientationMask) -> Effect<Never>
+    let setOrientationMask: (UIInterfaceOrientationMask) -> Effect<Never>
 }
 
 extension AppDelegateClient {
@@ -27,13 +27,13 @@ extension AppDelegateClient {
         }
     )
 
-    func setPortraitOrientation() -> EffectTask<Never> {
+    func setPortraitOrientation() -> Effect<Never> {
         setOrientation(.portrait)
     }
-    func setAllOrientationMask() -> EffectTask<Never> {
+    func setAllOrientationMask() -> Effect<Never> {
         setOrientationMask([.all])
     }
-    func setPortraitOrientationMask() -> EffectTask<Never> {
+    func setPortraitOrientationMask() -> Effect<Never> {
         setOrientationMask([.portrait, .portraitUpsideDown])
     }
 }

--- a/EhPanda/App/Tools/Clients/AuthorizationClient.swift
+++ b/EhPanda/App/Tools/Clients/AuthorizationClient.swift
@@ -11,7 +11,7 @@ import ComposableArchitecture
 
 struct AuthorizationClient {
     let passcodeNotSet: () -> Bool
-    let localAuthroize: (String) -> EffectTask<Bool>
+    let localAuthroize: (String) -> Effect<Bool>
 }
 
 extension AuthorizationClient {

--- a/EhPanda/App/Tools/Clients/AuthorizationClient.swift
+++ b/EhPanda/App/Tools/Clients/AuthorizationClient.swift
@@ -21,21 +21,21 @@ extension AuthorizationClient {
             return !LAContext().canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)
         },
         localAuthroize: { reason in
-            Future { promise in
-                let context = LAContext()
-                var error: NSError?
+            Effect.publisher {
+                Future { promise in
+                    let context = LAContext()
+                    var error: NSError?
 
-                if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
-                    context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { isSuccess, _ in
-                        promise(.success(isSuccess))
+                    if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
+                        context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { isSuccess, _ in
+                            promise(.success(isSuccess))
+                        }
+                    } else {
+                        promise(.success(false))
                     }
-                } else {
-                    promise(.success(false))
                 }
+                .receive(on: DispatchQueue.main)
             }
-            .eraseToAnyPublisher()
-            .receive(on: DispatchQueue.main)
-            .eraseToEffect()
         }
     )
 }

--- a/EhPanda/App/Tools/Clients/ClipboardClient.swift
+++ b/EhPanda/App/Tools/Clients/ClipboardClient.swift
@@ -12,8 +12,8 @@ import UniformTypeIdentifiers
 struct ClipboardClient {
     let url: () -> URL?
     let changeCount: () -> Int
-    let saveText: (String) -> EffectTask<Never>
-    let saveImage: (UIImage, Bool) -> EffectTask<Never>
+    let saveText: (String) -> Effect<Never>
+    let saveImage: (UIImage, Bool) -> Effect<Never>
 }
 
 extension ClipboardClient {

--- a/EhPanda/App/Tools/Clients/ClipboardClient.swift
+++ b/EhPanda/App/Tools/Clients/ClipboardClient.swift
@@ -29,12 +29,12 @@ extension ClipboardClient {
             UIPasteboard.general.changeCount
         },
         saveText: { text in
-            .fireAndForget {
+            .run(operation: { _ in
                 UIPasteboard.general.string = text
-            }
+            })
         },
         saveImage: { (image, isAnimated) in
-            .fireAndForget {
+            .run(operation: { _ in
                 if isAnimated {
                     DispatchQueue.global(qos: .utility).async {
                         if let data = image.kf.data(format: .GIF) {
@@ -44,7 +44,7 @@ extension ClipboardClient {
                 } else {
                     UIPasteboard.general.image = image
                 }
-            }
+            })
         }
     )
 }

--- a/EhPanda/App/Tools/Clients/CookieClient.swift
+++ b/EhPanda/App/Tools/Clients/CookieClient.swift
@@ -19,13 +19,13 @@ struct CookieClient {
 extension CookieClient {
     static let live: Self = .init(
         clearAll: {
-            .fireAndForget {
+            .run(operation: { _ in
                 if let historyCookies = HTTPCookieStorage.shared.cookies {
                     historyCookies.forEach {
                         HTTPCookieStorage.shared.deleteCookie($0)
                     }
                 }
-            }
+            })
         },
         getCookie: { url, key in
             var value = CookieValue(
@@ -109,13 +109,13 @@ extension CookieClient {
         HTTPCookieStorage.shared.setCookie(cookie)
     }
     func setOrEditCookie(for url: URL, key: String, value: String) -> Effect<Never> {
-        .fireAndForget {
+        .run(operation: { _ in
             if checkExistence(url, key) {
                 editCookie(for: url, key: key, value: value)
             } else {
                 setCookie(for: url, key: key, value: value)
             }
-        }
+        })
     }
 }
 
@@ -139,10 +139,10 @@ extension CookieClient {
         && getCookie(url, Defaults.Cookie.igneous).rawValue.isEmpty
     }
     func removeYay() -> Effect<Never> {
-        .fireAndForget {
+        .run(operation: { _ in
             removeCookie(Defaults.URL.exhentai, Defaults.Cookie.yay)
             removeCookie(Defaults.URL.sexhentai, Defaults.Cookie.yay)
-        }
+        })
     }
     func syncExCookies() -> Effect<Never> {
         .merge(
@@ -234,7 +234,7 @@ extension CookieClient {
         return effects.isEmpty ? .none : .merge(effects)
     }
     func setCredentials(response: HTTPURLResponse) -> Effect<Never> {
-        .fireAndForget {
+        .run(operation: { _ in
             guard let setString = response.allHeaderFields["Set-Cookie"] as? String else { return }
             setString.components(separatedBy: ", ")
                 .flatMap { $0.components(separatedBy: "; ") }.forEach { value in
@@ -250,10 +250,10 @@ extension CookieClient {
                         }
                     }
                 }
-        }
+        })
     }
     func setSkipServer(response: HTTPURLResponse) -> Effect<Never> {
-        .fireAndForget {
+        .run(operation: { _ in
             guard let setString = response.allHeaderFields["Set-Cookie"] as? String else { return }
             setString.components(separatedBy: ", ")
                 .flatMap { $0.components(separatedBy: "; ") }
@@ -266,7 +266,7 @@ extension CookieClient {
                         )
                     }
                 }
-        }
+        })
     }
 }
 

--- a/EhPanda/App/Tools/Clients/CookieClient.swift
+++ b/EhPanda/App/Tools/Clients/CookieClient.swift
@@ -9,7 +9,7 @@ import Foundation
 import ComposableArchitecture
 
 struct CookieClient {
-    let clearAll: () -> EffectTask<Never>
+    let clearAll: () -> Effect<Never>
     let getCookie: (URL, String) -> CookieValue
     private let removeCookie: (URL, String) -> Void
     private let checkExistence: (URL, String) -> Bool
@@ -108,7 +108,7 @@ extension CookieClient {
         guard let cookie = newCookie else { return }
         HTTPCookieStorage.shared.setCookie(cookie)
     }
-    func setOrEditCookie(for url: URL, key: String, value: String) -> EffectTask<Never> {
+    func setOrEditCookie(for url: URL, key: String, value: String) -> Effect<Never> {
         .fireAndForget {
             if checkExistence(url, key) {
                 editCookie(for: url, key: key, value: value)
@@ -138,13 +138,13 @@ extension CookieClient {
         && !getCookie(url, Defaults.Cookie.ipbPassHash).rawValue.isEmpty
         && getCookie(url, Defaults.Cookie.igneous).rawValue.isEmpty
     }
-    func removeYay() -> EffectTask<Never> {
+    func removeYay() -> Effect<Never> {
         .fireAndForget {
             removeCookie(Defaults.URL.exhentai, Defaults.Cookie.yay)
             removeCookie(Defaults.URL.sexhentai, Defaults.Cookie.yay)
         }
     }
-    func syncExCookies() -> EffectTask<Never> {
+    func syncExCookies() -> Effect<Never> {
         .merge(
             [
                 Defaults.Cookie.ipbMemberId,
@@ -160,13 +160,13 @@ extension CookieClient {
             }
         )
     }
-    func ignoreOffensive() -> EffectTask<Never> {
+    func ignoreOffensive() -> Effect<Never> {
         .merge(
             setOrEditCookie(for: Defaults.URL.ehentai, key: Defaults.Cookie.ignoreOffensive, value: "1"),
             setOrEditCookie(for: Defaults.URL.exhentai, key: Defaults.Cookie.ignoreOffensive, value: "1")
         )
     }
-    func fulfillAnotherHostField() -> EffectTask<Never> {
+    func fulfillAnotherHostField() -> Effect<Never> {
         let ehURL = Defaults.URL.ehentai
         let exURL = Defaults.URL.exhentai
         let memberIdKey = Defaults.Cookie.ipbMemberId
@@ -218,8 +218,8 @@ extension CookieClient {
 
 // MARK: SetCookies
 extension CookieClient {
-    func setCookies(state: CookiesState, trimsSpaces: Bool = true) -> EffectTask<Never> {
-        let effects: [EffectTask<Never>] = state.allCases
+    func setCookies(state: CookiesState, trimsSpaces: Bool = true) -> Effect<Never> {
+        let effects: [Effect<Never>] = state.allCases
             .flatMap { subState in
                 state.host.cookieURLs
                     .map {
@@ -233,7 +233,7 @@ extension CookieClient {
             }
         return effects.isEmpty ? .none : .merge(effects)
     }
-    func setCredentials(response: HTTPURLResponse) -> EffectTask<Never> {
+    func setCredentials(response: HTTPURLResponse) -> Effect<Never> {
         .fireAndForget {
             guard let setString = response.allHeaderFields["Set-Cookie"] as? String else { return }
             setString.components(separatedBy: ", ")
@@ -252,7 +252,7 @@ extension CookieClient {
                 }
         }
     }
-    func setSkipServer(response: HTTPURLResponse) -> EffectTask<Never> {
+    func setSkipServer(response: HTTPURLResponse) -> Effect<Never> {
         .fireAndForget {
             guard let setString = response.allHeaderFields["Set-Cookie"] as? String else { return }
             setString.components(separatedBy: ", ")

--- a/EhPanda/App/Tools/Clients/DFClient.swift
+++ b/EhPanda/App/Tools/Clients/DFClient.swift
@@ -10,7 +10,7 @@ import Kingfisher
 import ComposableArchitecture
 
 struct DFClient {
-    let setActive: (Bool) -> EffectTask<Never>
+    let setActive: (Bool) -> Effect<Never>
 }
 
 extension DFClient {

--- a/EhPanda/App/Tools/Clients/DFClient.swift
+++ b/EhPanda/App/Tools/Clients/DFClient.swift
@@ -16,7 +16,7 @@ struct DFClient {
 extension DFClient {
     static let live: Self = .init(
         setActive: { newValue in
-            .fireAndForget {
+            .run(operation: { _ in
                 if newValue {
                     URLProtocol.registerClass(DFURLProtocol.self)
                 } else {
@@ -26,7 +26,7 @@ extension DFClient {
                 let config = KingfisherManager.shared.downloader.sessionConfiguration
                 config.protocolClasses = newValue ? [DFURLProtocol.self] : nil
                 KingfisherManager.shared.downloader.sessionConfiguration = config
-            }
+            })
         }
     )
 }

--- a/EhPanda/App/Tools/Clients/DatabaseClient.swift
+++ b/EhPanda/App/Tools/Clients/DatabaseClient.swift
@@ -290,21 +290,21 @@ extension DatabaseClient {
 extension DatabaseClient {
     func updateGallery(gid: String, key: String, value: Any?) -> Effect<Never> {
         guard gid.isValidGID else { return .none }
-        return .fireAndForget {
+        return .run(operation: { _ in
             DispatchQueue.main.async {
                 update(
                     entityType: GalleryMO.self, gid: gid, createIfNil: true,
                     commitChanges: { $0.setValue(value, forKeyPath: key) }
                 )
             }
-        }
+        })
     }
     func updateLastOpenDate(gid: String, date: Date = .now) -> Effect<Never> {
         guard gid.isValidGID else { return .none }
         return updateGallery(gid: gid, key: "lastOpenDate", value: date)
     }
     func clearHistoryGalleries() -> Effect<Never> {
-        .fireAndForget {
+        .run(operation: { _ in
             DispatchQueue.main.async {
                 let predicate = NSPredicate(format: "lastOpenDate != nil")
                 batchUpdate(entityType: GalleryMO.self, predicate: predicate) { galleryMOs in
@@ -313,10 +313,10 @@ extension DatabaseClient {
                     }
                 }
             }
-        }
+        })
     }
     func cacheGalleries(_ galleries: [Gallery]) -> Effect<Never> {
-        .fireAndForget {
+        .run(operation: { _ in
             DispatchQueue.main.async {
                 for gallery in galleries.filter({ $0.id.isValidGID }) {
                     let storedMO = fetch(
@@ -342,7 +342,7 @@ extension DatabaseClient {
                 }
                 saveContext()
             }
-        }
+        })
     }
 }
 
@@ -350,7 +350,7 @@ extension DatabaseClient {
 extension DatabaseClient {
     func cacheGalleryDetail(_ detail: GalleryDetail) -> Effect<Never> {
         guard detail.gid.isValidGID else { return .none }
-        return .fireAndForget {
+        return .run(operation: { _ in
             DispatchQueue.main.async {
                 let storedMO = fetch(
                     entityType: GalleryDetailMO.self, gid: detail.gid
@@ -380,7 +380,7 @@ extension DatabaseClient {
                 }
                 saveContext()
             }
-        }
+        })
     }
 }
 
@@ -388,14 +388,14 @@ extension DatabaseClient {
 extension DatabaseClient {
     func updateGalleryState(gid: String, commitChanges: @escaping (GalleryStateMO) -> Void) -> Effect<Never> {
         guard gid.isValidGID else { return .none }
-        return .fireAndForget {
+        return .run(operation: { _ in
             DispatchQueue.main.async {
                 update(
                     entityType: GalleryStateMO.self, gid: gid, createIfNil: true,
                     commitChanges: commitChanges
                 )
             }
-        }
+        })
     }
     func updateGalleryState(gid: String, key: String, value: Any?) -> Effect<Never> {
         guard gid.isValidGID else { return .none }
@@ -430,7 +430,7 @@ extension DatabaseClient {
         }
     }
     func removeImageURLs() -> Effect<Never> {
-        .fireAndForget {
+        .run(operation: { _ in
             DispatchQueue.main.async {
                 batchUpdate(entityType: GalleryStateMO.self) { galleryStateMOs in
                     galleryStateMOs.forEach { galleryStateMO in
@@ -441,7 +441,7 @@ extension DatabaseClient {
                     }
                 }
             }
-        }
+        })
     }
     func removeExpiredImageURLs() -> Effect<Never> {
         fetchHistoryGalleries()
@@ -490,14 +490,14 @@ extension DatabaseClient {
 // MARK: UpdateAppEnv
 extension DatabaseClient {
     func updateAppEnv(key: String, value: Any?) -> Effect<Never> {
-        .fireAndForget {
+        .run(operation: { _ in
             DispatchQueue.main.async {
                 update(
                     entityType: AppEnvMO.self, createIfNil: true,
                     commitChanges: { $0.setValue(value, forKeyPath: key) }
                 )
             }
-        }
+        })
     }
     func updateSetting(_ setting: Setting) -> Effect<Never> {
         updateAppEnv(key: "setting", value: setting.toData())

--- a/EhPanda/App/Tools/Clients/FileClient.swift
+++ b/EhPanda/App/Tools/Clients/FileClient.swift
@@ -11,9 +11,9 @@ import ComposableArchitecture
 
 struct FileClient {
     let createFile: (String, Data?) -> Bool
-    let fetchLogs: () -> EffectTask<Result<[Log], AppError>>
-    let deleteLog: (String) -> EffectTask<Result<String, AppError>>
-    let importTagTranslator: (URL) -> EffectTask<Result<TagTranslator, AppError>>
+    let fetchLogs: () -> Effect<Result<[Log], AppError>>
+    let deleteLog: (String) -> Effect<Result<String, AppError>>
+    let importTagTranslator: (URL) -> Effect<Result<TagTranslator, AppError>>
 }
 
 extension FileClient {

--- a/EhPanda/App/Tools/Clients/ImageClient.swift
+++ b/EhPanda/App/Tools/Clients/ImageClient.swift
@@ -12,10 +12,10 @@ import Kingfisher
 import ComposableArchitecture
 
 struct ImageClient {
-    let prefetchImages: ([URL]) -> EffectTask<Never>
-    let saveImageToPhotoLibrary: (UIImage, Bool) -> EffectTask<Bool>
-    let downloadImage: (URL) -> EffectTask<Result<UIImage, Error>>
-    let retrieveImage: (String) -> EffectTask<Result<UIImage, Error>>
+    let prefetchImages: ([URL]) -> Effect<Never>
+    let saveImageToPhotoLibrary: (UIImage, Bool) -> Effect<Bool>
+    let downloadImage: (URL) -> Effect<Result<UIImage, Error>>
+    let retrieveImage: (String) -> Effect<Result<UIImage, Error>>
 }
 
 extension ImageClient {
@@ -78,7 +78,7 @@ extension ImageClient {
         }
     )
 
-    func fetchImage(url: URL) -> EffectTask<Result<UIImage, Error>> {
+    func fetchImage(url: URL) -> Effect<Result<UIImage, Error>> {
         if KingfisherManager.shared.cache.isCached(forKey: url.absoluteString) {
             return retrieveImage(url.absoluteString)
         } else {

--- a/EhPanda/App/Tools/Clients/ImageClient.swift
+++ b/EhPanda/App/Tools/Clients/ImageClient.swift
@@ -21,9 +21,9 @@ struct ImageClient {
 extension ImageClient {
     static let live: Self = .init(
         prefetchImages: { urls in
-            .fireAndForget {
+            .run(operation: { _ in
                 ImagePrefetcher(urls: urls).start()
-            }
+            })
         },
         saveImageToPhotoLibrary: { (image, isAnimated) in
             Future { promise in

--- a/EhPanda/App/Tools/Clients/LibraryClient.swift
+++ b/EhPanda/App/Tools/Clients/LibraryClient.swift
@@ -14,11 +14,11 @@ import UIImageColors
 import ComposableArchitecture
 
 struct LibraryClient {
-    let initializeLogger: () -> EffectTask<Never>
-    let initializeWebImage: () -> EffectTask<Never>
-    let clearWebImageDiskCache: () -> EffectTask<Never>
-    let analyzeImageColors: (UIImage) -> EffectTask<UIImageColors?>
-    let calculateWebImageDiskCacheSize: () -> EffectTask<UInt?>
+    let initializeLogger: () -> Effect<Never>
+    let initializeWebImage: () -> Effect<Never>
+    let clearWebImageDiskCache: () -> Effect<Never>
+    let analyzeImageColors: (UIImage) -> Effect<UIImageColors?>
+    let calculateWebImageDiskCacheSize: () -> Effect<UInt?>
 }
 
 extension LibraryClient {

--- a/EhPanda/App/Tools/Clients/LibraryClient.swift
+++ b/EhPanda/App/Tools/Clients/LibraryClient.swift
@@ -67,23 +67,23 @@ extension LibraryClient {
             })
         },
         analyzeImageColors: { image in
-            Future { promise in
-                image.getColors(quality: .lowest) { colors in
-                    promise(.success(colors))
+            Effect.publisher {
+                Future { promise in
+                    image.getColors(quality: .lowest) { colors in
+                        promise(.success(colors))
+                    }
                 }
             }
-            .eraseToAnyPublisher()
-            .eraseToEffect()
         },
         calculateWebImageDiskCacheSize: {
-            Future { promise in
-                KingfisherManager.shared.cache.calculateDiskStorageSize {
-                    promise(.success(try? $0.get()))
+            Effect.publisher {
+                Future { promise in
+                    KingfisherManager.shared.cache.calculateDiskStorageSize {
+                        promise(.success(try? $0.get()))
+                    }
                 }
+                .receive(on: DispatchQueue.main)
             }
-            .eraseToAnyPublisher()
-            .receive(on: DispatchQueue.main)
-            .eraseToEffect()
         }
     )
 }

--- a/EhPanda/App/Tools/Clients/LibraryClient.swift
+++ b/EhPanda/App/Tools/Clients/LibraryClient.swift
@@ -24,7 +24,7 @@ struct LibraryClient {
 extension LibraryClient {
     static let live: Self = .init(
         initializeLogger: {
-            .fireAndForget {
+            .run(operation: { _ in
                 // MARK: SwiftyBeaver
                 let file = FileDestination()
                 let console = ConsoleDestination()
@@ -52,19 +52,19 @@ extension LibraryClient {
                 #if DEBUG
                 SwiftyBeaver.addDestination(console)
                 #endif
-            }
+            })
         },
         initializeWebImage: {
-            .fireAndForget {
+            .run(operation: { _ in
                 let config = KingfisherManager.shared.downloader.sessionConfiguration
                 config.httpCookieStorage = HTTPCookieStorage.shared
                 KingfisherManager.shared.downloader.sessionConfiguration = config
-            }
+            })
         },
         clearWebImageDiskCache: {
-            .fireAndForget {
+            .run(operation: { _ in
                 KingfisherManager.shared.cache.clearDiskCache()
-            }
+            })
         },
         analyzeImageColors: { image in
             Future { promise in

--- a/EhPanda/App/Tools/Clients/LoggerClient.swift
+++ b/EhPanda/App/Tools/Clients/LoggerClient.swift
@@ -8,8 +8,8 @@
 import ComposableArchitecture
 
 struct LoggerClient {
-    let info: (Any, Any?) -> EffectTask<Never>
-    let error: (Any, Any?) -> EffectTask<Never>
+    let info: (Any, Any?) -> Effect<Never>
+    let error: (Any, Any?) -> Effect<Never>
 }
 
 extension LoggerClient {

--- a/EhPanda/App/Tools/Clients/LoggerClient.swift
+++ b/EhPanda/App/Tools/Clients/LoggerClient.swift
@@ -15,14 +15,14 @@ struct LoggerClient {
 extension LoggerClient {
     static let live: Self = .init(
         info: { message, context in
-            .fireAndForget {
+            .run(operation: { _ in
                 Logger.info(message, context: context)
-            }
+            })
         },
         error: { message, context in
-            .fireAndForget {
+            .run(operation: { _ in
                 Logger.error(message, context: context)
-            }
+            })
         }
     )
 }

--- a/EhPanda/App/Tools/Clients/UIApplicationClient.swift
+++ b/EhPanda/App/Tools/Clients/UIApplicationClient.swift
@@ -10,11 +10,11 @@ import Combine
 import ComposableArchitecture
 
 struct UIApplicationClient {
-    let openURL: (URL) -> EffectTask<Never>
-    let hideKeyboard: () -> EffectTask<Never>
+    let openURL: (URL) -> Effect<Never>
+    let hideKeyboard: () -> Effect<Never>
     let alternateIconName: () -> String?
-    let setAlternateIconName: (String?) -> EffectTask<Result<Bool, Never>>
-    let setUserInterfaceStyle: (UIUserInterfaceStyle) -> EffectTask<Never>
+    let setAlternateIconName: (String?) -> Effect<Result<Bool, Never>>
+    let setUserInterfaceStyle: (UIUserInterfaceStyle) -> Effect<Never>
 }
 
 extension UIApplicationClient {
@@ -51,13 +51,13 @@ extension UIApplicationClient {
             }
         }
     )
-    func openSettings() -> EffectTask<Never> {
+    func openSettings() -> Effect<Never> {
         if let url = URL(string: UIApplication.openSettingsURLString) {
             return openURL(url)
         }
         return .none
     }
-    func openFileApp() -> EffectTask<Never> {
+    func openFileApp() -> Effect<Never> {
         if let dirPath = FileUtil.logsDirectoryURL?.path,
            let dirURL = URL(string: "shareddocuments://" + dirPath)
         {

--- a/EhPanda/App/Tools/Clients/UserDefaultsClient.swift
+++ b/EhPanda/App/Tools/Clients/UserDefaultsClient.swift
@@ -9,7 +9,7 @@ import Foundation
 import ComposableArchitecture
 
 struct UserDefaultsClient {
-    let setValue: (Any, AppUserDefaults) -> EffectTask<Never>
+    let setValue: (Any, AppUserDefaults) -> Effect<Never>
 }
 
 extension UserDefaultsClient {

--- a/EhPanda/App/Tools/Clients/UserDefaultsClient.swift
+++ b/EhPanda/App/Tools/Clients/UserDefaultsClient.swift
@@ -15,9 +15,9 @@ struct UserDefaultsClient {
 extension UserDefaultsClient {
     static let live: Self = .init(
         setValue: { value, key in
-            .fireAndForget {
+            .run(operation: { _ in
                 UserDefaults.standard.set(value, forKey: key.rawValue)
-            }
+            })
         }
     )
 

--- a/EhPanda/App/Tools/Extensions/Reducer_Extension.swift
+++ b/EhPanda/App/Tools/Extensions/Reducer_Extension.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 import ComposableArchitecture
 
-extension ReducerProtocol {
+extension Reducer {
     func haptics<Enum, Case>(
         unwrapping enum: @escaping (State) -> Enum?,
         case casePath: CasePath<Enum, Case>,
         hapticsClient: HapticsClient,
         style: UIImpactFeedbackGenerator.FeedbackStyle = .light
-    ) -> some ReducerProtocol<State, Action> {
+    ) -> some Reducer<State, Action> {
         onBecomeNonNil(unwrapping: `enum`, case: casePath) { _, _ in
             .fireAndForget({ hapticsClient.generateFeedback(style) })
         }
@@ -24,7 +24,7 @@ extension ReducerProtocol {
         unwrapping enum: @escaping (State) -> Enum?,
         case casePath: CasePath<Enum, Case>,
         perform additionalEffects: @escaping (inout State, Action) -> Effect<Action>
-    ) -> some ReducerProtocol<State, Action> {
+    ) -> some Reducer<State, Action> {
         Reduce { state, action in
             let previousCase = Binding.constant(`enum`(state)).case(casePath).wrappedValue
             let effects = reduce(into: &state, action: action)
@@ -38,7 +38,7 @@ extension ReducerProtocol {
 }
 
 // MARK: Recurse
-struct RecurseReducer<State, Action, Base: ReducerProtocol>: ReducerProtocol
+struct RecurseReducer<State, Action, Base: Reducer>: Reducer
 where State == Base.State, Action == Base.Action {
     let base: (Reduce<State, Action>) -> Base
 
@@ -46,7 +46,7 @@ where State == Base.State, Action == Base.Action {
         self.base = base
     }
 
-    public var body: some ReducerProtocol<State, Action> {
+    public var body: some Reducer<State, Action> {
         var `self`: Reduce<State, Action>!
         self = Reduce { state, action in
             base(self).reduce(into: &state, action: action)
@@ -56,7 +56,7 @@ where State == Base.State, Action == Base.Action {
 }
 
 // MARK: Logging
-struct LoggingReducer<State, Action, Base: ReducerProtocol>: ReducerProtocol
+struct LoggingReducer<State, Action, Base: Reducer>: Reducer
 where State == Base.State, Action == Base.Action {
     let base: Base
 
@@ -65,7 +65,7 @@ where State == Base.State, Action == Base.Action {
     }
 
     @ReducerBuilder<State, Action>
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         Reduce { state, action in
             if case .setting(.binding(let bindingAction)) = action as? AppReducer.Action {
                 Logger.info("setting(EhPanda.SettingReducer.Action.\(bindingAction.customDumpDescription)")

--- a/EhPanda/App/Tools/Extensions/Reducer_Extension.swift
+++ b/EhPanda/App/Tools/Extensions/Reducer_Extension.swift
@@ -16,7 +16,7 @@ extension Reducer {
         style: UIImpactFeedbackGenerator.FeedbackStyle = .light
     ) -> some Reducer<State, Action> {
         onBecomeNonNil(unwrapping: `enum`, case: casePath) { _, _ in
-            .fireAndForget({ hapticsClient.generateFeedback(style) })
+            .run(operation: { _ in hapticsClient.generateFeedback(style) })
         }
     }
 

--- a/EhPanda/App/Tools/Extensions/Reducer_Extension.swift
+++ b/EhPanda/App/Tools/Extensions/Reducer_Extension.swift
@@ -23,7 +23,7 @@ extension ReducerProtocol {
     private func onBecomeNonNil<Enum, Case>(
         unwrapping enum: @escaping (State) -> Enum?,
         case casePath: CasePath<Enum, Case>,
-        perform additionalEffects: @escaping (inout State, Action) -> EffectTask<Action>
+        perform additionalEffects: @escaping (inout State, Action) -> Effect<Action>
     ) -> some ReducerProtocol<State, Action> {
         Reduce { state, action in
             let previousCase = Binding.constant(`enum`(state)).case(casePath).wrappedValue

--- a/EhPanda/DataFlow/AppDelegateReducer.swift
+++ b/EhPanda/DataFlow/AppDelegateReducer.swift
@@ -56,7 +56,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let store = Store(initialState: .init()) {
         AppReducer()
     }
-    lazy var viewStore = ViewStore(store)
+    lazy var viewStore = ViewStore(store, observe: { $0 })
 
     static var orientationMask: UIInterfaceOrientationMask = DeviceUtil.isPad ? .all : [.portrait, .portraitUpsideDown]
 

--- a/EhPanda/DataFlow/AppDelegateReducer.swift
+++ b/EhPanda/DataFlow/AppDelegateReducer.swift
@@ -53,10 +53,9 @@ struct AppDelegateReducer: Reducer {
 
 // MARK: AppDelegate
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    let store = Store(
-        initialState: .init(),
-        reducer: AppReducer()
-    )
+    let store = Store(initialState: .init()) {
+        AppReducer()
+    }
     lazy var viewStore = ViewStore(store)
 
     static var orientationMask: UIInterfaceOrientationMask = DeviceUtil.isPad ? .all : [.portrait, .portraitUpsideDown]

--- a/EhPanda/DataFlow/AppDelegateReducer.swift
+++ b/EhPanda/DataFlow/AppDelegateReducer.swift
@@ -36,7 +36,7 @@ struct AppDelegateReducer: Reducer {
                     cookieClient.syncExCookies().fireAndForget(),
                     cookieClient.ignoreOffensive().fireAndForget(),
                     cookieClient.fulfillAnotherHostField().fireAndForget(),
-                    .init(value: .migration(.prepareDatabase))
+                    Effect.send(.migration(.prepareDatabase))
                 )
 
             case .removeExpiredImageURLs:

--- a/EhPanda/DataFlow/AppDelegateReducer.swift
+++ b/EhPanda/DataFlow/AppDelegateReducer.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import SwiftyBeaver
 import ComposableArchitecture
 
-struct AppDelegateReducer: ReducerProtocol {
+struct AppDelegateReducer: Reducer {
     struct State: Equatable {
         var migrationState = MigrationReducer.State()
     }
@@ -25,7 +25,7 @@ struct AppDelegateReducer: ReducerProtocol {
     @Dependency(\.libraryClient) private var libraryClient
     @Dependency(\.cookieClient) private var cookieClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         Reduce { _, action in
             switch action {
             case .onLaunchFinish:

--- a/EhPanda/DataFlow/AppLockReducer.swift
+++ b/EhPanda/DataFlow/AppLockReducer.swift
@@ -39,11 +39,11 @@ struct AppLockReducer: Reducer {
                    Date.now.timeIntervalSince(date) >= Double(threshold)
                 {
                     return .merge(
-                        .init(value: .authorize),
-                        .init(value: .lockApp(blurRadius))
+                        Effect.send(.authorize),
+                        Effect.send(.lockApp(blurRadius))
                     )
                 } else {
-                    return .init(value: .unlockApp)
+                    return Effect.send(.unlockApp)
                 }
 
             case .onBecomeInactive(let blurRadius):
@@ -67,7 +67,7 @@ struct AppLockReducer: Reducer {
                     .map(Action.authorizeDone)
 
             case .authorizeDone(let isSucceeded):
-                return isSucceeded ? .init(value: .unlockApp) : .none
+                return isSucceeded ? Effect.send(.unlockApp) : .none
             }
         }
     }

--- a/EhPanda/DataFlow/AppLockReducer.swift
+++ b/EhPanda/DataFlow/AppLockReducer.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import ComposableArchitecture
 
-struct AppLockReducer: ReducerProtocol {
+struct AppLockReducer: Reducer {
     struct State: Equatable {
         @BindingState var blurRadius: Double = 0
         var becameInactiveDate: Date?
@@ -31,7 +31,7 @@ struct AppLockReducer: ReducerProtocol {
 
     @Dependency(\.authorizationClient) private var authorizationClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
             case .onBecomeActive(let threshold, let blurRadius):

--- a/EhPanda/DataFlow/AppReducer.swift
+++ b/EhPanda/DataFlow/AppReducer.swift
@@ -82,7 +82,7 @@ struct AppReducer: ReducerProtocol {
                     return .none
 
                 case .appRoute(.clearSubStates):
-                    var effects = [EffectTask<Action>]()
+                    var effects = [Effect<Action>]()
                     if deviceClient.isPad() {
                         state.settingState.route = nil
                         effects.append(.init(value: .setting(.clearSubStates)))
@@ -93,7 +93,7 @@ struct AppReducer: ReducerProtocol {
                     return .none
 
                 case .appLock(.unlockApp):
-                    var effects: [EffectTask<Action>] = [
+                    var effects: [Effect<Action>] = [
                         .init(value: .setting(.fetchGreeting))
                     ]
                     if state.settingState.setting.detectsLinksFromClipboard {
@@ -105,8 +105,8 @@ struct AppReducer: ReducerProtocol {
                     return .none
 
                 case .tabBar(.setTabBarItemType(let type)):
-                    var effects = [EffectTask<Action>]()
-                    let hapticEffect: EffectTask<Action> = .fireAndForget({ hapticsClient.generateFeedback(.soft) })
+                    var effects = [Effect<Action>]()
+                    let hapticEffect: Effect<Action> = .fireAndForget({ hapticsClient.generateFeedback(.soft) })
                     if type == state.tabBarState.tabBarItemType {
                         switch type {
                         case .home:
@@ -148,7 +148,7 @@ struct AppReducer: ReducerProtocol {
                     return .none
 
                 case .home(.watched(.onNotLoginViewButtonTapped)), .favorites(.onNotLoginViewButtonTapped):
-                    var effects: [EffectTask<Action>] = [
+                    var effects: [Effect<Action>] = [
                         .fireAndForget({ hapticsClient.generateFeedback(.soft) }),
                         .init(value: .tabBar(.setTabBarItemType(.setting)))
                     ]
@@ -175,7 +175,7 @@ struct AppReducer: ReducerProtocol {
                     return .none
 
                 case .setting(.loadUserSettingsDone):
-                    var effects = [EffectTask<Action>]()
+                    var effects = [Effect<Action>]()
                     let threshold = state.settingState.setting.autoLockPolicy.rawValue
                     let blurRadius = state.settingState.setting.backgroundBlurRadius
                     if threshold >= 0 {

--- a/EhPanda/DataFlow/AppReducer.swift
+++ b/EhPanda/DataFlow/AppReducer.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import ComposableArchitecture
 
-struct AppReducer: ReducerProtocol {
+struct AppReducer: Reducer {
     struct State: Equatable {
         var appDelegateState = AppDelegateReducer.State()
         var appRouteState = AppRouteReducer.State()
@@ -40,7 +40,7 @@ struct AppReducer: ReducerProtocol {
     @Dependency(\.cookieClient) private var cookieClient
     @Dependency(\.deviceClient) private var deviceClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         LoggingReducer {
             BindingReducer()
 

--- a/EhPanda/DataFlow/AppReducer.swift
+++ b/EhPanda/DataFlow/AppReducer.swift
@@ -155,12 +155,13 @@ struct AppReducer: Reducer {
                     effects.append(Effect.send(.setting(.setNavigation(.account))))
                     if !cookieClient.didLogin {
                         effects.append(
-                            Effect.send(.setting(.account(.setNavigation(.login))))
-                            .delay(
-                                for: .milliseconds(deviceClient.isPad() ? 1200 : 200),
-                                scheduler: DispatchQueue.main
-                            )
-                            .eraseToEffect()
+                            Effect.publisher {
+                                Effect.send(.setting(.account(.setNavigation(.login))))
+                                    .delay(
+                                        for: .milliseconds(deviceClient.isPad() ? 1200 : 200),
+                                        scheduler: DispatchQueue.main
+                                    )
+                            }
                         )
                     }
                     return .merge(effects)

--- a/EhPanda/DataFlow/AppReducer.swift
+++ b/EhPanda/DataFlow/AppReducer.swift
@@ -106,7 +106,7 @@ struct AppReducer: Reducer {
 
                 case .tabBar(.setTabBarItemType(let type)):
                     var effects = [Effect<Action>]()
-                    let hapticEffect: Effect<Action> = .fireAndForget({ hapticsClient.generateFeedback(.soft) })
+                    let hapticEffect: Effect<Action> = .run(operation: { _ in hapticsClient.generateFeedback(.soft) })
                     if type == state.tabBarState.tabBarItemType {
                         switch type {
                         case .home:
@@ -149,7 +149,7 @@ struct AppReducer: Reducer {
 
                 case .home(.watched(.onNotLoginViewButtonTapped)), .favorites(.onNotLoginViewButtonTapped):
                     var effects: [Effect<Action>] = [
-                        .fireAndForget({ hapticsClient.generateFeedback(.soft) }),
+                        .run(operation: { _ in hapticsClient.generateFeedback(.soft) }),
                         Effect.send(.tabBar(.setTabBarItemType(.setting)))
                     ]
                     effects.append(Effect.send(.setting(.setNavigation(.account))))

--- a/EhPanda/DataFlow/AppRouteReducer.swift
+++ b/EhPanda/DataFlow/AppRouteReducer.swift
@@ -59,14 +59,14 @@ struct AppRouteReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? .init(value: .clearSubStates) : .none
+                return state.route == nil ? Effect.send(.clearSubStates) : .none
 
             case .binding:
                 return .none
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? .init(value: .clearSubStates) : .none
+                return route == nil ? Effect.send(.clearSubStates) : .none
 
             case .setHUDConfig(let config):
                 state.hudConfig = config
@@ -74,7 +74,7 @@ struct AppRouteReducer: Reducer {
 
             case .clearSubStates:
                 state.detailState = .init()
-                return .init(value: .detail(.teardown))
+                return Effect.send(.detail(.teardown))
 
             case .detectClipboardURL:
                 let currentChangeCount = clipboardClient.changeCount()
@@ -85,7 +85,7 @@ struct AppRouteReducer: Reducer {
                         .setValue(currentChangeCount, .clipboardChangeCount).fireAndForget()
                 ]
                 if let url = clipboardClient.url() {
-                    effects.append(.init(value: .handleDeepLink(url)))
+                    effects.append(Effect.send(.handleDeepLink(url)))
                 }
                 return .merge(effects)
 
@@ -101,10 +101,10 @@ struct AppRouteReducer: Reducer {
                 let (isGalleryImageURL, _, _) = urlClient.analyzeURL(url)
                 let gid = urlClient.parseGalleryID(url)
                 guard databaseClient.fetchGallery(gid: gid) == nil else {
-                    return .init(value: .handleGalleryLink(url))
+                    return Effect.send(.handleGalleryLink(url))
                         .delay(for: .milliseconds(delay + 250), scheduler: DispatchQueue.main).eraseToEffect()
                 }
-                return .init(value: .fetchGallery(url, isGalleryImageURL))
+                return Effect.send(.fetchGallery(url, isGalleryImageURL))
                     .delay(for: .milliseconds(delay), scheduler: DispatchQueue.main).eraseToEffect()
 
             case .handleGalleryLink(let url):
@@ -112,21 +112,21 @@ struct AppRouteReducer: Reducer {
                 let gid = urlClient.parseGalleryID(url)
                 var effects = [Effect<Action>]()
                 state.detailState = .init()
-                effects.append(.init(value: .detail(.fetchDatabaseInfos(gid))))
+                effects.append(Effect.send(.detail(.fetchDatabaseInfos(gid))))
                 if let pageIndex = pageIndex {
-                    effects.append(.init(value: .updateReadingProgress(gid, pageIndex)))
+                    effects.append(Effect.send(.updateReadingProgress(gid, pageIndex)))
                     effects.append(
-                        .init(value: .detail(.setNavigation(.reading)))
+                        Effect.send(.detail(.setNavigation(.reading)))
                             .delay(for: .milliseconds(500), scheduler: DispatchQueue.main).eraseToEffect()
                     )
                 } else if let commentID = commentID {
                     state.detailState.commentsState?.scrollCommentID = commentID
                     effects.append(
-                        .init(value: .detail(.setNavigation(.comments(url))))
+                        Effect.send(.detail(.setNavigation(.comments(url))))
                             .delay(for: .milliseconds(500), scheduler: DispatchQueue.main).eraseToEffect()
                     )
                 }
-                effects.append(.init(value: .setNavigation(.detail(gid))))
+                effects.append(Effect.send(.setNavigation(.detail(gid))))
                 return .merge(effects)
 
             case .updateReadingProgress(let gid, let progress):
@@ -145,16 +145,16 @@ struct AppRouteReducer: Reducer {
                 case .success(let gallery):
                     return .merge(
                         databaseClient.cacheGalleries([gallery]).fireAndForget(),
-                        .init(value: .handleGalleryLink(url))
+                        Effect.send(.handleGalleryLink(url))
                     )
                 case .failure:
-                    return .init(value: .setHUDConfig(.error))
+                    return Effect.send(.setHUDConfig(.error))
                         .delay(for: .milliseconds(500), scheduler: DispatchQueue.main).eraseToEffect()
                 }
 
             case .fetchGreetingDone(let result):
                 if case .success(let greeting) = result, !greeting.gainedNothing {
-                    return .init(value: .setNavigation(.newDawn(greeting)))
+                    return Effect.send(.setNavigation(.newDawn(greeting)))
                 }
                 return .none
 

--- a/EhPanda/DataFlow/AppRouteReducer.swift
+++ b/EhPanda/DataFlow/AppRouteReducer.swift
@@ -80,7 +80,7 @@ struct AppRouteReducer: ReducerProtocol {
                 let currentChangeCount = clipboardClient.changeCount()
                 guard currentChangeCount != userDefaultsClient
                         .getValue(.clipboardChangeCount) else { return .none }
-                var effects: [EffectTask<Action>] = [
+                var effects: [Effect<Action>] = [
                     userDefaultsClient
                         .setValue(currentChangeCount, .clipboardChangeCount).fireAndForget()
                 ]
@@ -110,7 +110,7 @@ struct AppRouteReducer: ReducerProtocol {
             case .handleGalleryLink(let url):
                 let (_, pageIndex, commentID) = urlClient.analyzeURL(url)
                 let gid = urlClient.parseGalleryID(url)
-                var effects = [EffectTask<Action>]()
+                var effects = [Effect<Action>]()
                 state.detailState = .init()
                 effects.append(.init(value: .detail(.fetchDatabaseInfos(gid))))
                 if let pageIndex = pageIndex {

--- a/EhPanda/DataFlow/AppRouteReducer.swift
+++ b/EhPanda/DataFlow/AppRouteReducer.swift
@@ -101,11 +101,15 @@ struct AppRouteReducer: Reducer {
                 let (isGalleryImageURL, _, _) = urlClient.analyzeURL(url)
                 let gid = urlClient.parseGalleryID(url)
                 guard databaseClient.fetchGallery(gid: gid) == nil else {
-                    return Effect.send(.handleGalleryLink(url))
-                        .delay(for: .milliseconds(delay + 250), scheduler: DispatchQueue.main).eraseToEffect()
+                    return Effect.publisher {
+                        Effect.send(.handleGalleryLink(url))
+                            .delay(for: .milliseconds(delay + 250), scheduler: DispatchQueue.main)
+                    }
                 }
-                return Effect.send(.fetchGallery(url, isGalleryImageURL))
-                    .delay(for: .milliseconds(delay), scheduler: DispatchQueue.main).eraseToEffect()
+                return Effect.publisher {
+                    Effect.send(.fetchGallery(url, isGalleryImageURL))
+                        .delay(for: .milliseconds(delay), scheduler: DispatchQueue.main)
+                }
 
             case .handleGalleryLink(let url):
                 let (_, pageIndex, commentID) = urlClient.analyzeURL(url)
@@ -116,14 +120,18 @@ struct AppRouteReducer: Reducer {
                 if let pageIndex = pageIndex {
                     effects.append(Effect.send(.updateReadingProgress(gid, pageIndex)))
                     effects.append(
-                        Effect.send(.detail(.setNavigation(.reading)))
-                            .delay(for: .milliseconds(500), scheduler: DispatchQueue.main).eraseToEffect()
+                        Effect.publisher {
+                            Effect.send(.detail(.setNavigation(.reading)))
+                                .delay(for: .milliseconds(500), scheduler: DispatchQueue.main)
+                        }
                     )
                 } else if let commentID = commentID {
                     state.detailState.commentsState?.scrollCommentID = commentID
                     effects.append(
-                        Effect.send(.detail(.setNavigation(.comments(url))))
-                            .delay(for: .milliseconds(500), scheduler: DispatchQueue.main).eraseToEffect()
+                        Effect.publisher {
+                            Effect.send(.detail(.setNavigation(.comments(url))))
+                                .delay(for: .milliseconds(500), scheduler: DispatchQueue.main)
+                        }
                     )
                 }
                 effects.append(Effect.send(.setNavigation(.detail(gid))))
@@ -148,8 +156,10 @@ struct AppRouteReducer: Reducer {
                         Effect.send(.handleGalleryLink(url))
                     )
                 case .failure:
-                    return Effect.send(.setHUDConfig(.error))
-                        .delay(for: .milliseconds(500), scheduler: DispatchQueue.main).eraseToEffect()
+                    return Effect.publisher {
+                        Effect.send(Action.setHUDConfig(.error))
+                            .delay(for: .milliseconds(500), scheduler: DispatchQueue.main)
+                    }
                 }
 
             case .fetchGreetingDone(let result):

--- a/EhPanda/DataFlow/AppRouteReducer.swift
+++ b/EhPanda/DataFlow/AppRouteReducer.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import TTProgressHUD
 import ComposableArchitecture
 
-struct AppRouteReducer: ReducerProtocol {
+struct AppRouteReducer: Reducer {
     enum Route: Equatable, Hashable {
         case hud
         case setting
@@ -53,7 +53,7 @@ struct AppRouteReducer: ReducerProtocol {
     @Dependency(\.hapticsClient) private var hapticsClient
     @Dependency(\.urlClient) private var urlClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/Network/Request.swift
+++ b/EhPanda/Network/Request.swift
@@ -16,7 +16,7 @@ protocol Request {
     var publisher: AnyPublisher<Response, AppError> { get }
 }
 extension Request {
-    var effect: EffectTask<Result<Response, AppError>> {
+    var effect: Effect<Result<Response, AppError>> {
         publisher.receive(on: DispatchQueue.main).catchToEffect()
     }
 

--- a/EhPanda/View/Detail/Archives/ArchivesReducer.swift
+++ b/EhPanda/View/Detail/Archives/ArchivesReducer.swift
@@ -9,7 +9,7 @@ import Foundation
 import TTProgressHUD
 import ComposableArchitecture
 
-struct ArchivesReducer: ReducerProtocol {
+struct ArchivesReducer: Reducer {
     enum Route {
         case messageHUD
         case communicatingHUD
@@ -49,7 +49,7 @@ struct ArchivesReducer: ReducerProtocol {
     @Dependency(\.hapticsClient) private var hapticsClient
     @Dependency(\.cookieClient) private var cookieClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Detail/Archives/ArchivesReducer.swift
+++ b/EhPanda/View/Detail/Archives/ArchivesReducer.swift
@@ -66,7 +66,7 @@ struct ArchivesReducer: Reducer {
                     .updateGalleryFunds(galleryPoints: galleryPoints, credits: credits).fireAndForget()
 
             case .teardown:
-                return .cancel(ids: CancelID.allCases)
+                return .merge(CancelID.allCases.map(Effect.cancel(id:)))
 
             case .fetchArchive(let gid, let galleryURL, let archiveURL):
                 guard state.loadingState != .loading else { return .none }

--- a/EhPanda/View/Detail/Archives/ArchivesReducer.swift
+++ b/EhPanda/View/Detail/Archives/ArchivesReducer.swift
@@ -85,9 +85,9 @@ struct ArchivesReducer: Reducer {
                     }
                     state.hathArchives = archive.hathArchives
                     if let galleryPoints = galleryPoints, let credits = credits {
-                        return .init(value: .syncGalleryFunds(galleryPoints, credits))
+                        return Effect.send(.syncGalleryFunds(galleryPoints, credits))
                     } else if cookieClient.isSameAccount {
-                        return .init(value: .fetchArchiveFunds(gid, galleryURL))
+                        return Effect.send(.fetchArchiveFunds(gid, galleryURL))
                     } else {
                         return .none
                     }
@@ -103,7 +103,7 @@ struct ArchivesReducer: Reducer {
 
             case .fetchArchiveFundsDone(let result):
                 if case .success(let (galleryPoints, credits)) = result {
-                    return .init(value: .syncGalleryFunds(galleryPoints, credits))
+                    return Effect.send(.syncGalleryFunds(galleryPoints, credits))
                 }
                 return .none
 

--- a/EhPanda/View/Detail/Archives/ArchivesReducer.swift
+++ b/EhPanda/View/Detail/Archives/ArchivesReducer.swift
@@ -140,7 +140,7 @@ struct ArchivesReducer: Reducer {
                     state.messageHUDConfig = .error
                     isSuccess = false
                 }
-                return .fireAndForget({ hapticsClient.generateNotificationFeedback(isSuccess ? .success : .error) })
+                return .run(operation: { _ in hapticsClient.generateNotificationFeedback(isSuccess ? .success : .error) })
             }
         }
     }

--- a/EhPanda/View/Detail/Archives/ArchivesView.swift
+++ b/EhPanda/View/Detail/Archives/ArchivesView.swift
@@ -33,7 +33,7 @@ struct ArchivesView: View {
         NavigationView {
             ZStack {
                 VStack {
-                    HathArchivesView(archives: viewStore.hathArchives, selection: viewStore.binding(\.$selectedArchive))
+                    HathArchivesView(archives: viewStore.hathArchives, selection: viewStore.$selectedArchive)
                     Spacer()
                     if let credits = Int(user.credits ?? ""), let galleryPoints = Int(user.galleryPoints ?? "") {
                         ArchiveFundsView(credits: credits, galleryPoints: galleryPoints)
@@ -55,12 +55,12 @@ struct ArchivesView: View {
             }
             .progressHUD(
                 config: viewStore.communicatingHUDConfig,
-                unwrapping: viewStore.binding(\.$route),
+                unwrapping: viewStore.$route,
                 case: /ArchivesReducer.Route.communicatingHUD
             )
             .progressHUD(
                 config: viewStore.messageHUDConfig,
-                unwrapping: viewStore.binding(\.$route),
+                unwrapping: viewStore.$route,
                 case: /ArchivesReducer.Route.messageHUD
             )
             .animation(.default, value: viewStore.hathArchives)

--- a/EhPanda/View/Detail/Archives/ArchivesView.swift
+++ b/EhPanda/View/Detail/Archives/ArchivesView.swift
@@ -21,7 +21,7 @@ struct ArchivesView: View {
         gid: String, user: User, galleryURL: URL, archiveURL: URL
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.gid = gid
         self.user = user
         self.galleryURL = galleryURL

--- a/EhPanda/View/Detail/Archives/ArchivesView.swift
+++ b/EhPanda/View/Detail/Archives/ArchivesView.swift
@@ -221,10 +221,9 @@ private struct DownloadButton: View {
 struct ArchivesView_Previews: PreviewProvider {
     static var previews: some View {
         ArchivesView(
-            store: .init(
-                initialState: .init(),
-                reducer: ArchivesReducer()
-            ),
+            store: .init(initialState: .init()) {
+                ArchivesReducer()
+            },
             gid: .init(),
             user: .init(),
             galleryURL: .mock,

--- a/EhPanda/View/Detail/Comments/CommentsReducer.swift
+++ b/EhPanda/View/Detail/Comments/CommentsReducer.swift
@@ -135,7 +135,7 @@ struct CommentsReducer: ReducerProtocol {
             case .handleGalleryLink(let url):
                 let (_, pageIndex, commentID) = urlClient.analyzeURL(url)
                 let gid = urlClient.parseGalleryID(url)
-                var effects = [EffectTask<Action>]()
+                var effects = [Effect<Action>]()
                 if let pageIndex = pageIndex {
                     effects.append(.init(value: .updateReadingProgress(gid, pageIndex)))
                     effects.append(

--- a/EhPanda/View/Detail/Comments/CommentsReducer.swift
+++ b/EhPanda/View/Detail/Comments/CommentsReducer.swift
@@ -113,12 +113,18 @@ struct CommentsReducer: Reducer {
 
             case .performScrollOpacityEffect:
                 return .merge(
-                    Effect.send(.setScrollRowOpacity(0.25))
-                        .delay(for: .milliseconds(750), scheduler: DispatchQueue.main).eraseToEffect(),
-                    Effect.send(.setScrollRowOpacity(1))
-                        .delay(for: .milliseconds(1250), scheduler: DispatchQueue.main).eraseToEffect(),
-                    Effect.send(.clearScrollCommentID)
-                        .delay(for: .milliseconds(2000), scheduler: DispatchQueue.main).eraseToEffect()
+                    Effect.publisher {
+                        Effect.send(.setScrollRowOpacity(0.25))
+                            .delay(for: .milliseconds(750), scheduler: DispatchQueue.main)
+                    },
+                    Effect.publisher {
+                        Effect.send(.setScrollRowOpacity(1))
+                            .delay(for: .milliseconds(1250), scheduler: DispatchQueue.main)
+                    },
+                    Effect.publisher {
+                        Effect.send(.clearScrollCommentID)
+                            .delay(for: .milliseconds(2000), scheduler: DispatchQueue.main)
+                    }
                 )
 
             case .handleCommentLink(let url):
@@ -139,22 +145,28 @@ struct CommentsReducer: Reducer {
                 if let pageIndex = pageIndex {
                     effects.append(Effect.send(.updateReadingProgress(gid, pageIndex)))
                     effects.append(
-                        Effect.send(.detail(.setNavigation(.reading)))
-                            .delay(for: .milliseconds(750), scheduler: DispatchQueue.main).eraseToEffect()
+                        Effect.publisher {
+                            Effect.send(.detail(.setNavigation(.reading)))
+                                .delay(for: .milliseconds(750), scheduler: DispatchQueue.main)
+                        }
                     )
                 } else if let commentID = commentID {
                     state.detailState.commentsState?.scrollCommentID = commentID
                     effects.append(
-                        Effect.send(.detail(.setNavigation(.comments(url))))
-                            .delay(for: .milliseconds(750), scheduler: DispatchQueue.main).eraseToEffect()
+                        Effect.publisher {
+                            Effect.send(.detail(.setNavigation(.comments(url))))
+                                .delay(for: .milliseconds(750), scheduler: DispatchQueue.main)
+                        }
                     )
                 }
                 effects.append(Effect.send(.setNavigation(.detail(gid))))
                 return .merge(effects)
 
             case .onPostCommentAppear:
-                return Effect.send(.setPostCommentFocused(true))
-                    .delay(for: .milliseconds(750), scheduler: DispatchQueue.main).eraseToEffect()
+                return Effect.publisher {
+                    Effect.send(.setPostCommentFocused(true))
+                        .delay(for: .milliseconds(750), scheduler: DispatchQueue.main)
+                }
 
             case .onAppear:
                 if state.detailState == nil {
@@ -209,8 +221,10 @@ struct CommentsReducer: Reducer {
                         Effect.send(.handleGalleryLink(url))
                     )
                 case .failure:
-                    return Effect.send(.setHUDConfig(.error))
-                        .delay(for: .milliseconds(500), scheduler: DispatchQueue.main).eraseToEffect()
+                    return Effect.publisher {
+                        Effect.send(.setHUDConfig(.error))
+                            .delay(for: .milliseconds(500), scheduler: DispatchQueue.main)
+                    }
                 }
 
             case .detail:

--- a/EhPanda/View/Detail/Comments/CommentsReducer.swift
+++ b/EhPanda/View/Detail/Comments/CommentsReducer.swift
@@ -180,7 +180,7 @@ struct CommentsReducer: Reducer {
                     .updateReadingProgress(gid: gid, progress: progress).fireAndForget()
 
             case .teardown:
-                return .cancel(ids: CancelID.allCases)
+                return .merge(CancelID.allCases.map(Effect.cancel(id:)))
 
             case .postComment(let galleryURL, let commentID):
                 guard !state.commentContent.isEmpty else { return .none }

--- a/EhPanda/View/Detail/Comments/CommentsReducer.swift
+++ b/EhPanda/View/Detail/Comments/CommentsReducer.swift
@@ -9,7 +9,7 @@ import Foundation
 import TTProgressHUD
 import ComposableArchitecture
 
-struct CommentsReducer: ReducerProtocol {
+struct CommentsReducer: Reducer {
     enum Route: Equatable {
         case hud
         case detail(String)
@@ -70,7 +70,7 @@ struct CommentsReducer: ReducerProtocol {
     @Dependency(\.cookieClient) private var cookieClient
     @Dependency(\.urlClient) private var urlClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Detail/Comments/CommentsView.swift
+++ b/EhPanda/View/Detail/Comments/CommentsView.swift
@@ -272,10 +272,9 @@ struct CommentsView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             CommentsView(
-                store: .init(
-                    initialState: .init(),
-                    reducer: CommentsReducer()
-                ),
+                store: .init(initialState: .init()) {
+                    CommentsReducer()
+                },
                 gid: .init(),
                 token: .init(),
                 apiKey: .init(),

--- a/EhPanda/View/Detail/Comments/CommentsView.swift
+++ b/EhPanda/View/Detail/Comments/CommentsView.swift
@@ -29,7 +29,7 @@ struct CommentsView: View {
         blurRadius: Double, tagTranslator: TagTranslator
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.gid = gid
         self.token = token
         self.apiKey = apiKey

--- a/EhPanda/View/Detail/Comments/CommentsView.swift
+++ b/EhPanda/View/Detail/Comments/CommentsView.swift
@@ -92,14 +92,14 @@ struct CommentsView: View {
                 }
             }
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /CommentsReducer.Route.postComment) { route in
+        .sheet(unwrapping: viewStore.$route, case: /CommentsReducer.Route.postComment) { route in
             let hasCommentID = !route.wrappedValue.isEmpty
             PostCommentView(
                 title: hasCommentID
                 ? L10n.Localizable.PostCommentView.Title.editComment
                 : L10n.Localizable.PostCommentView.Title.postComment,
-                content: viewStore.binding(\.$commentContent),
-                isFocused: viewStore.binding(\.$postCommentFocused),
+                content: viewStore.$commentContent,
+                isFocused: viewStore.$postCommentFocused,
                 postAction: {
                     if hasCommentID {
                         viewStore.send(.postComment(galleryURL, route.wrappedValue))
@@ -116,7 +116,7 @@ struct CommentsView: View {
         }
         .progressHUD(
             config: viewStore.hudConfig,
-            unwrapping: viewStore.binding(\.$route),
+            unwrapping: viewStore.$route,
             case: /CommentsReducer.Route.hud
         )
         .animation(.default, value: viewStore.scrollRowOpacity)
@@ -143,7 +143,7 @@ struct CommentsView: View {
 // MARK: NavigationLinks
 private extension CommentsView {
     @ViewBuilder var navigationLink: some View {
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /CommentsReducer.Route.detail) { route in
+        NavigationLink(unwrapping: viewStore.$route, case: /CommentsReducer.Route.detail) { route in
             DetailView(
                 store: store.scope(state: \.detailState, action: CommentsReducer.Action.detail),
                 gid: route.wrappedValue, user: user, setting: $setting,

--- a/EhPanda/View/Detail/DetailReducer.swift
+++ b/EhPanda/View/Detail/DetailReducer.swift
@@ -231,7 +231,7 @@ struct DetailReducer: Reducer {
                         .updateReadingProgress(gid: state.gallery.id, progress: progress).fireAndForget()
 
                 case .teardown:
-                    return .cancel(ids: CancelID.allCases)
+                    return .merge(CancelID.allCases.map(Effect.cancel(id:)))
 
                 case .fetchDatabaseInfos(let gid):
                     guard let gallery = databaseClient.fetchGallery(gid: gid) else { return .none }

--- a/EhPanda/View/Detail/DetailReducer.swift
+++ b/EhPanda/View/Detail/DetailReducer.swift
@@ -166,11 +166,11 @@ struct DetailReducer: Reducer {
 
                 case .toggleShowFullTitle:
                     state.showsFullTitle.toggle()
-                    return .fireAndForget({ hapticsClient.generateFeedback(.soft) })
+                    return .run(operation: { _ in hapticsClient.generateFeedback(.soft) })
 
                 case .toggleShowUserRating:
                     state.showsUserRating.toggle()
-                    return .fireAndForget({ hapticsClient.generateFeedback(.soft) })
+                    return .run(operation: { _ in hapticsClient.generateFeedback(.soft) })
 
                 case .setCommentContent(let content):
                     state.commentContent = content
@@ -188,7 +188,7 @@ struct DetailReducer: Reducer {
                     state.updateRating(value: value)
                     return .merge(
                         Effect.send(.rateGallery),
-                        .fireAndForget({ hapticsClient.generateFeedback(.soft) }),
+                        .run(operation: { _ in hapticsClient.generateFeedback(.soft) }),
                         Effect.send(.confirmRatingDone).delay(for: 1, scheduler: DispatchQueue.main).eraseToEffect()
                     )
 
@@ -320,10 +320,10 @@ struct DetailReducer: Reducer {
                     if case .success = result {
                         return .merge(
                             Effect.send(.fetchGalleryDetail),
-                            .fireAndForget({ hapticsClient.generateNotificationFeedback(.success) })
+                            .run(operation: { _ in hapticsClient.generateNotificationFeedback(.success) })
                         )
                     }
-                    return .fireAndForget({ hapticsClient.generateNotificationFeedback(.error) })
+                    return .run(operation: { _ in hapticsClient.generateNotificationFeedback(.error) })
 
                 case .reading(.onPerformDismiss):
                     return Effect.send(.setNavigation(nil))

--- a/EhPanda/View/Detail/DetailReducer.swift
+++ b/EhPanda/View/Detail/DetailReducer.swift
@@ -259,7 +259,7 @@ struct DetailReducer: ReducerProtocol {
                     state.loadingState = .idle
                     switch result {
                     case .success(let (galleryDetail, galleryState, apiKey, greeting)):
-                        var effects: [EffectTask<Action>] = [
+                        var effects: [Effect<Action>] = [
                             .init(value: .syncGalleryTags),
                             .init(value: .syncGalleryDetail),
                             .init(value: .syncGalleryPreviewURLs),

--- a/EhPanda/View/Detail/DetailReducer.swift
+++ b/EhPanda/View/Detail/DetailReducer.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import Foundation
 import ComposableArchitecture
 
-struct DetailReducer: ReducerProtocol {
+struct DetailReducer: Reducer {
     enum Route: Equatable {
         case reading
         case archives(URL, URL)
@@ -115,7 +115,7 @@ struct DetailReducer: ReducerProtocol {
     @Dependency(\.hapticsClient) private var hapticsClient
     @Dependency(\.cookieClient) private var cookieClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         RecurseReducer { (self) in
             BindingReducer()
 

--- a/EhPanda/View/Detail/DetailReducer.swift
+++ b/EhPanda/View/Detail/DetailReducer.swift
@@ -151,8 +151,10 @@ struct DetailReducer: Reducer {
                     )
 
                 case .onPostCommentAppear:
-                    return Effect.send(.setPostCommentFocused(true))
-                        .delay(for: .milliseconds(750), scheduler: DispatchQueue.main).eraseToEffect()
+                    return Effect.publisher {
+                        Effect.send(.setPostCommentFocused(true))
+                            .delay(for: .milliseconds(750), scheduler: DispatchQueue.main)
+                    }
 
                 case .onAppear(let gid, let showsNewDawnGreeting):
                     state.showsNewDawnGreeting = showsNewDawnGreeting
@@ -189,7 +191,9 @@ struct DetailReducer: Reducer {
                     return .merge(
                         Effect.send(.rateGallery),
                         .run(operation: { _ in hapticsClient.generateFeedback(.soft) }),
-                        Effect.send(.confirmRatingDone).delay(for: 1, scheduler: DispatchQueue.main).eraseToEffect()
+                        Effect.publisher {
+                            Effect.send(.confirmRatingDone).delay(for: 1, scheduler: DispatchQueue.main)
+                        }
                     )
 
                 case .confirmRatingDone:

--- a/EhPanda/View/Detail/DetailSearch/DetailSearchReducer.swift
+++ b/EhPanda/View/Detail/DetailSearch/DetailSearchReducer.swift
@@ -95,7 +95,7 @@ struct DetailSearchReducer: Reducer {
                 )
 
             case .teardown:
-                return .cancel(ids: CancelID.allCases)
+                return .merge(CancelID.allCases.map(Effect.cancel(id:)))
 
             case .fetchGalleries(let keyword):
                 guard state.loadingState != .loading else { return .none }

--- a/EhPanda/View/Detail/DetailSearch/DetailSearchReducer.swift
+++ b/EhPanda/View/Detail/DetailSearch/DetailSearchReducer.swift
@@ -145,7 +145,7 @@ struct DetailSearchReducer: ReducerProtocol {
                     state.pageNumber = pageNumber
                     state.insertGalleries(galleries)
 
-                    var effects: [EffectTask<Action>] = [
+                    var effects: [Effect<Action>] = [
                         databaseClient.cacheGalleries(galleries).fireAndForget()
                     ]
                     if galleries.isEmpty, pageNumber.hasNextPage() {

--- a/EhPanda/View/Detail/DetailSearch/DetailSearchReducer.swift
+++ b/EhPanda/View/Detail/DetailSearch/DetailSearchReducer.swift
@@ -70,7 +70,7 @@ struct DetailSearchReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? .init(value: .clearSubStates) : .none
+                return state.route == nil ? Effect.send(.clearSubStates) : .none
 
             case .binding(\.$keyword):
                 if !state.keyword.isEmpty {
@@ -83,15 +83,15 @@ struct DetailSearchReducer: Reducer {
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? .init(value: .clearSubStates) : .none
+                return route == nil ? Effect.send(.clearSubStates) : .none
 
             case .clearSubStates:
                 state.detailState = .init()
                 state.filtersState = .init()
                 state.quickDetailSearchState = .init()
                 return .merge(
-                    .init(value: .detail(.teardown)),
-                    .init(value: .quickSearch(.teardown))
+                    Effect.send(.detail(.teardown)),
+                    Effect.send(.quickSearch(.teardown))
                 )
 
             case .teardown:
@@ -116,7 +116,7 @@ struct DetailSearchReducer: Reducer {
                     guard !galleries.isEmpty else {
                         state.loadingState = .failed(.notFound)
                         guard pageNumber.hasNextPage() else { return .none }
-                        return .init(value: .fetchMoreGalleries)
+                        return Effect.send(.fetchMoreGalleries)
                     }
                     state.pageNumber = pageNumber
                     state.galleries = galleries
@@ -149,7 +149,7 @@ struct DetailSearchReducer: Reducer {
                         databaseClient.cacheGalleries(galleries).fireAndForget()
                     ]
                     if galleries.isEmpty, pageNumber.hasNextPage() {
-                        effects.append(.init(value: .fetchMoreGalleries))
+                        effects.append(Effect.send(.fetchMoreGalleries))
                     } else if !galleries.isEmpty {
                         state.loadingState = .idle
                     }

--- a/EhPanda/View/Detail/DetailSearch/DetailSearchReducer.swift
+++ b/EhPanda/View/Detail/DetailSearch/DetailSearchReducer.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 
-struct DetailSearchReducer: ReducerProtocol {
+struct DetailSearchReducer: Reducer {
     enum Route: Equatable {
         case filters
         case quickSearch
@@ -64,7 +64,7 @@ struct DetailSearchReducer: ReducerProtocol {
     @Dependency(\.databaseClient) private var databaseClient
     @Dependency(\.hapticsClient) private var hapticsClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Detail/DetailSearch/DetailSearchView.swift
+++ b/EhPanda/View/Detail/DetailSearch/DetailSearchView.swift
@@ -122,10 +122,9 @@ struct DetailSearchView: View {
 struct DetailSearchView_Previews: PreviewProvider {
     static var previews: some View {
         DetailSearchView(
-            store: .init(
-                initialState: .init(),
-                reducer: DetailSearchReducer()
-            ),
+            store: .init(initialState: .init()) {
+                DetailSearchReducer()
+            },
             keyword: .init(),
             user: .init(),
             setting: .constant(.init()),

--- a/EhPanda/View/Detail/DetailSearch/DetailSearchView.swift
+++ b/EhPanda/View/Detail/DetailSearch/DetailSearchView.swift
@@ -45,7 +45,7 @@ struct DetailSearchView: View {
             }
         )
         .sheet(
-            unwrapping: viewStore.binding(\.$route),
+            unwrapping: viewStore.$route,
             case: /DetailSearchReducer.Route.detail,
             isEnabled: DeviceUtil.isPad
         ) { route in
@@ -58,7 +58,7 @@ struct DetailSearchView: View {
             }
             .autoBlur(radius: blurRadius).environment(\.inSheet, true).navigationViewStyle(.stack)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /DetailSearchReducer.Route.quickSearch) { _ in
+        .sheet(unwrapping: viewStore.$route, case: /DetailSearchReducer.Route.quickSearch) { _ in
             QuickSearchView(
                 store: store.scope(state: \.quickDetailSearchState, action: DetailSearchReducer.Action.quickSearch)
             ) { keyword in
@@ -68,14 +68,14 @@ struct DetailSearchView: View {
             .accentColor(setting.accentColor)
             .autoBlur(radius: blurRadius)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /DetailSearchReducer.Route.filters) { _ in
+        .sheet(unwrapping: viewStore.$route, case: /DetailSearchReducer.Route.filters) { _ in
             FiltersView(store: store.scope(state: \.filtersState, action: DetailSearchReducer.Action.filters))
                 .accentColor(setting.accentColor).autoBlur(radius: blurRadius)
         }
-        .searchable(text: viewStore.binding(\.$keyword))
+        .searchable(text: viewStore.$keyword)
         .searchSuggestions {
             TagSuggestionView(
-                keyword: viewStore.binding(\.$keyword), translations: tagTranslator.translations,
+                keyword: viewStore.$keyword, translations: tagTranslator.translations,
                 showsImages: setting.showsImagesInTags, isEnabled: setting.showsTagsSearchSuggestion
             )
         }
@@ -96,7 +96,7 @@ struct DetailSearchView: View {
 
     @ViewBuilder private var navigationLink: some View {
         if DeviceUtil.isPhone {
-            NavigationLink(unwrapping: viewStore.binding(\.$route), case: /DetailSearchReducer.Route.detail) { route in
+            NavigationLink(unwrapping: viewStore.$route, case: /DetailSearchReducer.Route.detail) { route in
                 DetailView(
                     store: store.scope(state: \.detailState, action: DetailSearchReducer.Action.detail),
                     gid: route.wrappedValue, user: user, setting: $setting,

--- a/EhPanda/View/Detail/DetailSearch/DetailSearchView.swift
+++ b/EhPanda/View/Detail/DetailSearch/DetailSearchView.swift
@@ -22,7 +22,7 @@ struct DetailSearchView: View {
         keyword: String, user: User, setting: Binding<Setting>, blurRadius: Double, tagTranslator: TagTranslator
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.keyword = keyword
         self.user = user
         _setting = setting

--- a/EhPanda/View/Detail/DetailView.swift
+++ b/EhPanda/View/Detail/DetailView.swift
@@ -121,7 +121,7 @@ struct DetailView: View {
             ErrorView(error: error ?? .unknown, action: error?.isRetryable != false ? retryAction : nil)
                 .opacity(viewStore.galleryDetail == nil && error != nil ? 1 : 0)
         }
-        .fullScreenCover(unwrapping: viewStore.binding(\.$route), case: /DetailReducer.Route.reading) { _ in
+        .fullScreenCover(unwrapping: viewStore.$route, case: /DetailReducer.Route.reading) { _ in
             ReadingView(
                 store: store.scope(state: \.readingState, action: DetailReducer.Action.reading),
                 gid: gid, setting: $setting, blurRadius: blurRadius
@@ -129,7 +129,7 @@ struct DetailView: View {
             .accentColor(setting.accentColor)
             .autoBlur(radius: blurRadius)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /DetailReducer.Route.archives) { route in
+        .sheet(unwrapping: viewStore.$route, case: /DetailReducer.Route.archives) { route in
             let (galleryURL, archiveURL) = route.wrappedValue
             ArchivesView(
                 store: store.scope(state: \.archivesState, action: DetailReducer.Action.archives),
@@ -138,7 +138,7 @@ struct DetailView: View {
             .accentColor(setting.accentColor)
             .autoBlur(radius: blurRadius)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /DetailReducer.Route.torrents) { _ in
+        .sheet(unwrapping: viewStore.$route, case: /DetailReducer.Route.torrents) { _ in
             TorrentsView(
                 store: store.scope(state: \.torrentsState, action: DetailReducer.Action.torrents),
                 gid: gid, token: viewStore.gallery.token, blurRadius: blurRadius
@@ -146,15 +146,15 @@ struct DetailView: View {
             .accentColor(setting.accentColor)
             .autoBlur(radius: blurRadius)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /DetailReducer.Route.share) { route in
+        .sheet(unwrapping: viewStore.$route, case: /DetailReducer.Route.share) { route in
             ActivityView(activityItems: [route.wrappedValue])
                 .autoBlur(radius: blurRadius)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /DetailReducer.Route.postComment) { _ in
+        .sheet(unwrapping: viewStore.$route, case: /DetailReducer.Route.postComment) { _ in
             PostCommentView(
                 title: L10n.Localizable.PostCommentView.Title.postComment,
-                content: viewStore.binding(\.$commentContent),
-                isFocused: viewStore.binding(\.$postCommentFocused),
+                content: viewStore.$commentContent,
+                isFocused: viewStore.$postCommentFocused,
                 postAction: {
                     if let galleryURL = viewStore.gallery.galleryURL {
                         viewStore.send(.postComment(galleryURL))
@@ -167,10 +167,10 @@ struct DetailView: View {
             .accentColor(setting.accentColor)
             .autoBlur(radius: blurRadius)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /DetailReducer.Route.newDawn) { route in
+        .sheet(unwrapping: viewStore.$route, case: /DetailReducer.Route.newDawn) { route in
             NewDawnView(greeting: route.wrappedValue).autoBlur(radius: blurRadius)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /DetailReducer.Route.tagDetail) { route in
+        .sheet(unwrapping: viewStore.$route, case: /DetailReducer.Route.tagDetail) { route in
             TagDetailView(detail: route.wrappedValue).autoBlur(radius: blurRadius)
         }
         .animation(.default, value: viewStore.showsUserRating)
@@ -189,13 +189,13 @@ struct DetailView: View {
 // MARK: NavigationLinks
 private extension DetailView {
     @ViewBuilder var navigationLinks: some View {
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /DetailReducer.Route.previews) { _ in
+        NavigationLink(unwrapping: viewStore.$route, case: /DetailReducer.Route.previews) { _ in
             PreviewsView(
                 store: store.scope(state: \.previewsState, action: DetailReducer.Action.previews),
                 gid: gid, setting: $setting, blurRadius: blurRadius
             )
         }
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /DetailReducer.Route.comments) { route in
+        NavigationLink(unwrapping: viewStore.$route, case: /DetailReducer.Route.comments) { route in
             IfLetStore(store.scope(state: \.commentsState, action: DetailReducer.Action.comments)) { store in
                 CommentsView(
                     store: store, gid: gid, token: viewStore.gallery.token, apiKey: viewStore.apiKey,
@@ -205,7 +205,7 @@ private extension DetailView {
                 )
             }
         }
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /DetailReducer.Route.detailSearch) { route in
+        NavigationLink(unwrapping: viewStore.$route, case: /DetailReducer.Route.detailSearch) { route in
             IfLetStore(store.scope(state: \.detailSearchState, action: DetailReducer.Action.detailSearch)) { store in
                 DetailSearchView(
                     store: store, keyword: route.wrappedValue, user: user, setting: $setting,
@@ -213,7 +213,7 @@ private extension DetailView {
                 )
             }
         }
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /DetailReducer.Route.galleryInfos) { route in
+        NavigationLink(unwrapping: viewStore.$route, case: /DetailReducer.Route.galleryInfos) { route in
             let (gallery, galleryDetail) = route.wrappedValue
             GalleryInfosView(
                 store: store.scope(state: \.galleryInfosState, action: DetailReducer.Action.galleryInfos),

--- a/EhPanda/View/Detail/DetailView.swift
+++ b/EhPanda/View/Detail/DetailView.swift
@@ -24,7 +24,7 @@ struct DetailView: View {
         user: User, setting: Binding<Setting>, blurRadius: Double, tagTranslator: TagTranslator
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.gid = gid
         self.user = user
         _setting = setting

--- a/EhPanda/View/Detail/DetailView.swift
+++ b/EhPanda/View/Detail/DetailView.swift
@@ -847,10 +847,9 @@ struct DetailView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             DetailView(
-                store: .init(
-                    initialState: .init(),
-                    reducer: DetailReducer()
-                ),
+                store: .init(initialState: .init()) {
+                    DetailReducer()
+                },
                 gid: .init(),
                 user: .init(),
                 setting: .constant(.init()),

--- a/EhPanda/View/Detail/GalleryInfos/GalleryInfosReducer.swift
+++ b/EhPanda/View/Detail/GalleryInfos/GalleryInfosReducer.swift
@@ -38,7 +38,7 @@ struct GalleryInfosReducer: Reducer {
                 state.route = .hud
                 return .merge(
                     clipboardClient.saveText(text).fireAndForget(),
-                    .fireAndForget({ hapticsClient.generateNotificationFeedback(.success) })
+                    .run(operation: { _ in hapticsClient.generateNotificationFeedback(.success) })
                 )
             }
         }

--- a/EhPanda/View/Detail/GalleryInfos/GalleryInfosReducer.swift
+++ b/EhPanda/View/Detail/GalleryInfos/GalleryInfosReducer.swift
@@ -8,7 +8,7 @@
 import TTProgressHUD
 import ComposableArchitecture
 
-struct GalleryInfosReducer: ReducerProtocol {
+struct GalleryInfosReducer: Reducer {
     enum Route {
         case hud
     }
@@ -26,7 +26,7 @@ struct GalleryInfosReducer: ReducerProtocol {
     @Dependency(\.clipboardClient) private var clipboardClient
     @Dependency(\.hapticsClient) private var hapticsClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Detail/GalleryInfos/GalleryInfosView.swift
+++ b/EhPanda/View/Detail/GalleryInfos/GalleryInfosView.swift
@@ -135,10 +135,9 @@ struct GalleryInfosView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             GalleryInfosView(
-                store: .init(
-                    initialState: .init(),
-                    reducer: GalleryInfosReducer()
-                ),
+                store: .init(initialState: .init()) {
+                    GalleryInfosReducer()
+                },
                 gallery: .preview,
                 galleryDetail: .preview
             )

--- a/EhPanda/View/Detail/GalleryInfos/GalleryInfosView.swift
+++ b/EhPanda/View/Detail/GalleryInfos/GalleryInfosView.swift
@@ -118,7 +118,7 @@ struct GalleryInfosView: View {
         }
         .progressHUD(
             config: viewStore.hudConfig,
-            unwrapping: viewStore.binding(\.$route),
+            unwrapping: viewStore.$route,
             case: /GalleryInfosReducer.Route.hud
         )
         .navigationTitle(L10n.Localizable.GalleryInfosView.Title.galleryInfos)

--- a/EhPanda/View/Detail/GalleryInfos/GalleryInfosView.swift
+++ b/EhPanda/View/Detail/GalleryInfos/GalleryInfosView.swift
@@ -16,7 +16,7 @@ struct GalleryInfosView: View {
 
     init(store: StoreOf<GalleryInfosReducer>, gallery: Gallery, galleryDetail: GalleryDetail) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.gallery = gallery
         self.galleryDetail = galleryDetail
     }

--- a/EhPanda/View/Detail/Previews/PreviewsReducer.swift
+++ b/EhPanda/View/Detail/Previews/PreviewsReducer.swift
@@ -84,7 +84,7 @@ struct PreviewsReducer: Reducer {
                     .updateReadingProgress(gid: state.gallery.id, progress: progress).fireAndForget()
 
             case .teardown:
-                return .cancel(ids: CancelID.allCases)
+                return .merge(CancelID.allCases.map(Effect.cancel(id:)))
 
             case .fetchDatabaseInfos(let gid):
                 guard let gallery = databaseClient.fetchGallery(gid: gid) else { return .none }

--- a/EhPanda/View/Detail/Previews/PreviewsReducer.swift
+++ b/EhPanda/View/Detail/Previews/PreviewsReducer.swift
@@ -8,7 +8,7 @@
 import Foundation
 import ComposableArchitecture
 
-struct PreviewsReducer: ReducerProtocol {
+struct PreviewsReducer: Reducer {
     enum Route {
         case reading
     }
@@ -56,7 +56,7 @@ struct PreviewsReducer: ReducerProtocol {
     @Dependency(\.databaseClient) private var databaseClient
     @Dependency(\.hapticsClient) private var hapticsClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Detail/Previews/PreviewsReducer.swift
+++ b/EhPanda/View/Detail/Previews/PreviewsReducer.swift
@@ -62,18 +62,18 @@ struct PreviewsReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? .init(value: .clearSubStates) : .none
+                return state.route == nil ? Effect.send(.clearSubStates) : .none
 
             case .binding:
                 return .none
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? .init(value: .clearSubStates) : .none
+                return route == nil ? Effect.send(.clearSubStates) : .none
 
             case .clearSubStates:
                 state.readingState = .init()
-                return .init(value: .reading(.teardown))
+                return Effect.send(.reading(.teardown))
 
             case .syncPreviewURLs(let previewURLs):
                 return databaseClient
@@ -119,14 +119,14 @@ struct PreviewsReducer: Reducer {
                         return .none
                     }
                     state.updatePreviewURLs(previewURLs)
-                    return .init(value: .syncPreviewURLs(previewURLs))
+                    return Effect.send(.syncPreviewURLs(previewURLs))
                 case .failure(let error):
                     state.loadingState = .failed(error)
                 }
                 return .none
 
             case .reading(.onPerformDismiss):
-                return .init(value: .setNavigation(nil))
+                return Effect.send(.setNavigation(nil))
 
             case .reading:
                 return .none

--- a/EhPanda/View/Detail/Previews/PreviewsView.swift
+++ b/EhPanda/View/Detail/Previews/PreviewsView.swift
@@ -21,7 +21,7 @@ struct PreviewsView: View {
         gid: String, setting: Binding<Setting>, blurRadius: Double
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.gid = gid
         _setting = setting
         self.blurRadius = blurRadius

--- a/EhPanda/View/Detail/Previews/PreviewsView.swift
+++ b/EhPanda/View/Detail/Previews/PreviewsView.swift
@@ -87,10 +87,9 @@ struct PreviewsView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             PreviewsView(
-                store: .init(
-                    initialState: .init(gallery: .preview),
-                    reducer: PreviewsReducer()
-                ),
+                store: .init(initialState: .init(gallery: .preview)) {
+                    PreviewsReducer()
+                },
                 gid: .init(),
                 setting: .constant(.init()),
                 blurRadius: 0

--- a/EhPanda/View/Detail/Previews/PreviewsView.swift
+++ b/EhPanda/View/Detail/Previews/PreviewsView.swift
@@ -68,7 +68,7 @@ struct PreviewsView: View {
             .padding(.bottom)
             .id(viewStore.databaseLoadingState)
         }
-        .fullScreenCover(unwrapping: viewStore.binding(\.$route), case: /PreviewsReducer.Route.reading) { _ in
+        .fullScreenCover(unwrapping: viewStore.$route, case: /PreviewsReducer.Route.reading) { _ in
             ReadingView(
                 store: store.scope(state: \.readingState, action: PreviewsReducer.Action.reading),
                 gid: gid, setting: $setting, blurRadius: blurRadius

--- a/EhPanda/View/Detail/Torrents/TorrentsReducer.swift
+++ b/EhPanda/View/Detail/Torrents/TorrentsReducer.swift
@@ -60,7 +60,7 @@ struct TorrentsReducer: Reducer {
                 state.route = .hud
                 return .merge(
                     clipboardClient.saveText(magnetURL).fireAndForget(),
-                    .fireAndForget({ hapticsClient.generateNotificationFeedback(.success) })
+                    .run(operation: { _ in hapticsClient.generateNotificationFeedback(.success) })
                 )
 
             case .presentTorrentActivity(let hash, let data):

--- a/EhPanda/View/Detail/Torrents/TorrentsReducer.swift
+++ b/EhPanda/View/Detail/Torrents/TorrentsReducer.swift
@@ -9,7 +9,7 @@ import Foundation
 import TTProgressHUD
 import ComposableArchitecture
 
-struct TorrentsReducer: ReducerProtocol {
+struct TorrentsReducer: Reducer {
     enum Route: Equatable {
         case hud
         case share(URL)
@@ -44,7 +44,7 @@ struct TorrentsReducer: ReducerProtocol {
     @Dependency(\.hapticsClient) private var hapticsClient
     @Dependency(\.fileClient) private var fileClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Detail/Torrents/TorrentsReducer.swift
+++ b/EhPanda/View/Detail/Torrents/TorrentsReducer.swift
@@ -74,7 +74,7 @@ struct TorrentsReducer: Reducer {
                     .cancellable(id: CancelID.fetchTorrent)
 
             case .teardown:
-                return .cancel(ids: CancelID.allCases)
+                return .merge(CancelID.allCases.map(Effect.cancel(id:)))
 
             case .fetchTorrentDone(let hash, let result):
                 if case .success(let data) = result, !data.isEmpty {

--- a/EhPanda/View/Detail/Torrents/TorrentsReducer.swift
+++ b/EhPanda/View/Detail/Torrents/TorrentsReducer.swift
@@ -65,7 +65,7 @@ struct TorrentsReducer: Reducer {
 
             case .presentTorrentActivity(let hash, let data):
                 if let url = fileClient.saveTorrent(hash: hash, data: data) {
-                    return .init(value: .setNavigation(.share(url)))
+                    return Effect.send(.setNavigation(.share(url)))
                 }
                 return .none
 
@@ -78,7 +78,7 @@ struct TorrentsReducer: Reducer {
 
             case .fetchTorrentDone(let hash, let result):
                 if case .success(let data) = result, !data.isEmpty {
-                    return .init(value: .presentTorrentActivity(hash, data))
+                    return Effect.send(.presentTorrentActivity(hash, data))
                 }
                 return .none
 

--- a/EhPanda/View/Detail/Torrents/TorrentsView.swift
+++ b/EhPanda/View/Detail/Torrents/TorrentsView.swift
@@ -118,10 +118,9 @@ private extension TorrentsView {
 struct TorrentsView_Previews: PreviewProvider {
     static var previews: some View {
         TorrentsView(
-            store: .init(
-                initialState: .init(),
-                reducer: TorrentsReducer()
-            ),
+            store: .init(initialState: .init()) {
+                TorrentsReducer()
+            },
             gid: .init(),
             token: .init(),
             blurRadius: 0

--- a/EhPanda/View/Detail/Torrents/TorrentsView.swift
+++ b/EhPanda/View/Detail/Torrents/TorrentsView.swift
@@ -17,7 +17,7 @@ struct TorrentsView: View {
 
     init(store: StoreOf<TorrentsReducer>, gid: String, token: String, blurRadius: Double) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.gid = gid
         self.token = token
         self.blurRadius = blurRadius

--- a/EhPanda/View/Detail/Torrents/TorrentsView.swift
+++ b/EhPanda/View/Detail/Torrents/TorrentsView.swift
@@ -45,13 +45,13 @@ struct TorrentsView: View {
                 }
                 .opacity(error != nil && viewStore.torrents.isEmpty ? 1 : 0)
             }
-            .sheet(unwrapping: viewStore.binding(\.$route), case: /TorrentsReducer.Route.share) { route in
+            .sheet(unwrapping: viewStore.$route, case: /TorrentsReducer.Route.share) { route in
                 ActivityView(activityItems: [route.wrappedValue])
                     .autoBlur(radius: blurRadius)
             }
             .progressHUD(
                 config: viewStore.hudConfig,
-                unwrapping: viewStore.binding(\.$route),
+                unwrapping: viewStore.$route,
                 case: /TorrentsReducer.Route.hud
             )
             .animation(.default, value: viewStore.torrents)

--- a/EhPanda/View/Favorites/FavoritesReducer.swift
+++ b/EhPanda/View/Favorites/FavoritesReducer.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import IdentifiedCollections
 import ComposableArchitecture
 
-struct FavoritesReducer: ReducerProtocol {
+struct FavoritesReducer: Reducer {
     enum Route: Equatable {
         case quickSearch
         case detail(String)
@@ -75,7 +75,7 @@ struct FavoritesReducer: ReducerProtocol {
     @Dependency(\.databaseClient) private var databaseClient
     @Dependency(\.hapticsClient) private var hapticsClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Favorites/FavoritesReducer.swift
+++ b/EhPanda/View/Favorites/FavoritesReducer.swift
@@ -81,23 +81,23 @@ struct FavoritesReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? .init(value: .clearSubStates) : .none
+                return state.route == nil ? Effect.send(.clearSubStates) : .none
 
             case .binding:
                 return .none
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? .init(value: .clearSubStates) : .none
+                return route == nil ? Effect.send(.clearSubStates) : .none
 
             case .setFavoritesIndex(let index):
                 state.index = index
                 guard state.galleries?.isEmpty != false else { return .none }
-                return .init(value: Action.fetchGalleries())
+                return Effect.send(Action.fetchGalleries())
 
             case .clearSubStates:
                 state.detailState = .init()
-                return .init(value: .detail(.teardown))
+                return Effect.send(.detail(.teardown))
 
             case .onNotLoginViewButtonTapped:
                 return .none
@@ -125,7 +125,7 @@ struct FavoritesReducer: Reducer {
                     guard !galleries.isEmpty else {
                         state.rawLoadingState[targetFavIndex] = .failed(.notFound)
                         guard pageNumber.hasNextPage() else { return .none }
-                        return .init(value: .fetchMoreGalleries)
+                        return Effect.send(.fetchMoreGalleries)
                     }
                     state.rawPageNumber[targetFavIndex] = pageNumber
                     state.rawGalleries[targetFavIndex] = galleries
@@ -164,7 +164,7 @@ struct FavoritesReducer: Reducer {
                         databaseClient.cacheGalleries(galleries).fireAndForget()
                     ]
                     if galleries.isEmpty, pageNumber.hasNextPage() {
-                        effects.append(.init(value: .fetchMoreGalleries))
+                        effects.append(Effect.send(.fetchMoreGalleries))
                     } else if !galleries.isEmpty {
                         state.rawLoadingState[targetFavIndex] = .idle
                     }

--- a/EhPanda/View/Favorites/FavoritesReducer.swift
+++ b/EhPanda/View/Favorites/FavoritesReducer.swift
@@ -160,7 +160,7 @@ struct FavoritesReducer: ReducerProtocol {
                     state.insertGalleries(index: targetFavIndex, galleries: galleries)
                     state.sortOrder = sortOrder
 
-                    var effects: [EffectTask<Action>] = [
+                    var effects: [Effect<Action>] = [
                         databaseClient.cacheGalleries(galleries).fireAndForget()
                     ]
                     if galleries.isEmpty, pageNumber.hasNextPage() {

--- a/EhPanda/View/Favorites/FavoritesView.swift
+++ b/EhPanda/View/Favorites/FavoritesView.swift
@@ -56,7 +56,7 @@ struct FavoritesView: View {
                 }
             }
             .sheet(
-                unwrapping: viewStore.binding(\.$route),
+                unwrapping: viewStore.$route,
                 case: /FavoritesReducer.Route.detail,
                 isEnabled: DeviceUtil.isPad
             ) { route in
@@ -69,7 +69,7 @@ struct FavoritesView: View {
                 }
                 .autoBlur(radius: blurRadius).environment(\.inSheet, true).navigationViewStyle(.stack)
             }
-            .sheet(unwrapping: viewStore.binding(\.$route), case: /FavoritesReducer.Route.quickSearch) { _ in
+            .sheet(unwrapping: viewStore.$route, case: /FavoritesReducer.Route.quickSearch) { _ in
                 QuickSearchView(
                     store: store.scope(state: \.quickSearchState, action: FavoritesReducer.Action.quickSearch)
                 ) { keyword in
@@ -79,10 +79,10 @@ struct FavoritesView: View {
                 .accentColor(setting.accentColor)
                 .autoBlur(radius: blurRadius)
             }
-            .searchable(text: viewStore.binding(\.$keyword))
+            .searchable(text: viewStore.$keyword)
             .searchSuggestions {
                 TagSuggestionView(
-                    keyword: viewStore.binding(\.$keyword), translations: tagTranslator.translations,
+                    keyword: viewStore.$keyword, translations: tagTranslator.translations,
                     showsImages: setting.showsImagesInTags, isEnabled: setting.showsTagsSearchSuggestion
                 )
             }
@@ -104,7 +104,7 @@ struct FavoritesView: View {
 
     @ViewBuilder private var navigationLink: some View {
         if DeviceUtil.isPhone {
-            NavigationLink(unwrapping: viewStore.binding(\.$route), case: /FavoritesReducer.Route.detail) { route in
+            NavigationLink(unwrapping: viewStore.$route, case: /FavoritesReducer.Route.detail) { route in
                 DetailView(
                     store: store.scope(state: \.detailState, action: FavoritesReducer.Action.detail),
                     gid: route.wrappedValue, user: user, setting: $setting,

--- a/EhPanda/View/Favorites/FavoritesView.swift
+++ b/EhPanda/View/Favorites/FavoritesView.swift
@@ -135,10 +135,9 @@ struct FavoritesView: View {
 struct FavoritesView_Previews: PreviewProvider {
     static var previews: some View {
         FavoritesView(
-            store: .init(
-                initialState: .init(),
-                reducer: FavoritesReducer()
-            ),
+            store: .init(initialState: .init()) {
+                FavoritesReducer()
+            },
             user: .init(),
             setting: .constant(.init()),
             blurRadius: 0,

--- a/EhPanda/View/Favorites/FavoritesView.swift
+++ b/EhPanda/View/Favorites/FavoritesView.swift
@@ -22,7 +22,7 @@ struct FavoritesView: View {
         user: User, setting: Binding<Setting>, blurRadius: Double, tagTranslator: TagTranslator
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.user = user
         _setting = setting
         self.blurRadius = blurRadius

--- a/EhPanda/View/Home/Frontpage/FrontpageReducer.swift
+++ b/EhPanda/View/Home/Frontpage/FrontpageReducer.swift
@@ -85,7 +85,7 @@ struct FrontpageReducer: Reducer {
                 return Effect.send(.detail(.teardown))
 
             case .teardown:
-                return .cancel(ids: CancelID.allCases)
+                return .merge(CancelID.allCases.map(Effect.cancel(id:)))
 
             case .fetchGalleries:
                 guard state.loadingState != .loading else { return .none }

--- a/EhPanda/View/Home/Frontpage/FrontpageReducer.swift
+++ b/EhPanda/View/Home/Frontpage/FrontpageReducer.swift
@@ -70,19 +70,19 @@ struct FrontpageReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? .init(value: .clearSubStates) : .none
+                return state.route == nil ? Effect.send(.clearSubStates) : .none
 
             case .binding:
                 return .none
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? .init(value: .clearSubStates) : .none
+                return route == nil ? Effect.send(.clearSubStates) : .none
 
             case .clearSubStates:
                 state.detailState = .init()
                 state.filtersState = .init()
-                return .init(value: .detail(.teardown))
+                return Effect.send(.detail(.teardown))
 
             case .teardown:
                 return .cancel(ids: CancelID.allCases)
@@ -103,7 +103,7 @@ struct FrontpageReducer: Reducer {
                     guard !galleries.isEmpty else {
                         state.loadingState = .failed(.notFound)
                         guard pageNumber.hasNextPage() else { return .none }
-                        return .init(value: .fetchMoreGalleries)
+                        return Effect.send(.fetchMoreGalleries)
                     }
                     state.pageNumber = pageNumber
                     state.galleries = galleries
@@ -136,7 +136,7 @@ struct FrontpageReducer: Reducer {
                         databaseClient.cacheGalleries(galleries).fireAndForget()
                     ]
                     if galleries.isEmpty, pageNumber.hasNextPage() {
-                        effects.append(.init(value: .fetchMoreGalleries))
+                        effects.append(Effect.send(.fetchMoreGalleries))
                     } else if !galleries.isEmpty {
                         state.loadingState = .idle
                     }

--- a/EhPanda/View/Home/Frontpage/FrontpageReducer.swift
+++ b/EhPanda/View/Home/Frontpage/FrontpageReducer.swift
@@ -132,7 +132,7 @@ struct FrontpageReducer: ReducerProtocol {
                     state.pageNumber = pageNumber
                     state.insertGalleries(galleries)
 
-                    var effects: [EffectTask<Action>] = [
+                    var effects: [Effect<Action>] = [
                         databaseClient.cacheGalleries(galleries).fireAndForget()
                     ]
                     if galleries.isEmpty, pageNumber.hasNextPage() {

--- a/EhPanda/View/Home/Frontpage/FrontpageReducer.swift
+++ b/EhPanda/View/Home/Frontpage/FrontpageReducer.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 
-struct FrontpageReducer: ReducerProtocol {
+struct FrontpageReducer: Reducer {
     enum Route: Equatable {
         case filters
         case detail(String)
@@ -64,7 +64,7 @@ struct FrontpageReducer: ReducerProtocol {
     @Dependency(\.databaseClient) private var databaseClient
     @Dependency(\.hapticsClient) private var hapticsClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Home/Frontpage/FrontpageView.swift
+++ b/EhPanda/View/Home/Frontpage/FrontpageView.swift
@@ -22,7 +22,7 @@ struct FrontpageView: View {
         user: User, setting: Binding<Setting>, blurRadius: Double, tagTranslator: TagTranslator
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.user = user
         _setting = setting
         self.blurRadius = blurRadius

--- a/EhPanda/View/Home/Frontpage/FrontpageView.swift
+++ b/EhPanda/View/Home/Frontpage/FrontpageView.swift
@@ -98,10 +98,9 @@ struct FrontpageView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             FrontpageView(
-                store: .init(
-                    initialState: .init(),
-                    reducer: FrontpageReducer()
-                ),
+                store: .init(initialState: .init()) {
+                    FrontpageReducer()
+                },
                 user: .init(),
                 setting: .constant(.init()),
                 blurRadius: 0,

--- a/EhPanda/View/Home/Frontpage/FrontpageView.swift
+++ b/EhPanda/View/Home/Frontpage/FrontpageView.swift
@@ -44,7 +44,7 @@ struct FrontpageView: View {
             }
         )
         .sheet(
-            unwrapping: viewStore.binding(\.$route),
+            unwrapping: viewStore.$route,
             case: /FrontpageReducer.Route.detail,
             isEnabled: DeviceUtil.isPad
         ) { route in
@@ -57,11 +57,11 @@ struct FrontpageView: View {
             }
             .autoBlur(radius: blurRadius).environment(\.inSheet, true).navigationViewStyle(.stack)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /FrontpageReducer.Route.filters) { _ in
+        .sheet(unwrapping: viewStore.$route, case: /FrontpageReducer.Route.filters) { _ in
             FiltersView(store: store.scope(state: \.filtersState, action: FrontpageReducer.Action.filters))
                 .autoBlur(radius: blurRadius).environment(\.inSheet, true)
         }
-        .searchable(text: viewStore.binding(\.$keyword), prompt: L10n.Localizable.Searchable.Prompt.filter)
+        .searchable(text: viewStore.$keyword, prompt: L10n.Localizable.Searchable.Prompt.filter)
         .onAppear {
             if viewStore.galleries.isEmpty {
                 DispatchQueue.main.async {
@@ -76,7 +76,7 @@ struct FrontpageView: View {
 
     @ViewBuilder private var navigationLink: some View {
         if DeviceUtil.isPhone {
-            NavigationLink(unwrapping: viewStore.binding(\.$route), case: /FrontpageReducer.Route.detail) { route in
+            NavigationLink(unwrapping: viewStore.$route, case: /FrontpageReducer.Route.detail) { route in
                 DetailView(
                     store: store.scope(state: \.detailState, action: FrontpageReducer.Action.detail),
                     gid: route.wrappedValue, user: user, setting: $setting,

--- a/EhPanda/View/Home/History/HistoryReducer.swift
+++ b/EhPanda/View/Home/History/HistoryReducer.swift
@@ -8,7 +8,7 @@
 import Foundation
 import ComposableArchitecture
 
-struct HistoryReducer: ReducerProtocol {
+struct HistoryReducer: Reducer {
     enum Route: Equatable {
         case detail(String)
         case clearHistory
@@ -48,7 +48,7 @@ struct HistoryReducer: ReducerProtocol {
     @Dependency(\.databaseClient) private var databaseClient
     @Dependency(\.hapticsClient) private var hapticsClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Home/History/HistoryReducer.swift
+++ b/EhPanda/View/Home/History/HistoryReducer.swift
@@ -54,23 +54,23 @@ struct HistoryReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? .init(value: .clearSubStates) : .none
+                return state.route == nil ? Effect.send(.clearSubStates) : .none
 
             case .binding:
                 return .none
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? .init(value: .clearSubStates) : .none
+                return route == nil ? Effect.send(.clearSubStates) : .none
 
             case .clearSubStates:
                 state.detailState = .init()
-                return .init(value: .detail(.teardown))
+                return Effect.send(.detail(.teardown))
 
             case .clearHistoryGalleries:
                 return .merge(
                     databaseClient.clearHistoryGalleries().fireAndForget(),
-                    .init(value: .fetchGalleries)
+                    Effect.send(.fetchGalleries)
                         .delay(for: .milliseconds(200), scheduler: DispatchQueue.main).eraseToEffect()
                 )
 

--- a/EhPanda/View/Home/History/HistoryReducer.swift
+++ b/EhPanda/View/Home/History/HistoryReducer.swift
@@ -70,8 +70,10 @@ struct HistoryReducer: Reducer {
             case .clearHistoryGalleries:
                 return .merge(
                     databaseClient.clearHistoryGalleries().fireAndForget(),
-                    Effect.send(.fetchGalleries)
-                        .delay(for: .milliseconds(200), scheduler: DispatchQueue.main).eraseToEffect()
+                    Effect.publisher {
+                        Effect.send(.fetchGalleries)
+                            .delay(for: .milliseconds(200), scheduler: DispatchQueue.main)
+                    }
                 )
 
             case .fetchGalleries:

--- a/EhPanda/View/Home/History/HistoryView.swift
+++ b/EhPanda/View/Home/History/HistoryView.swift
@@ -42,7 +42,7 @@ struct HistoryView: View {
             }
         )
         .sheet(
-            unwrapping: viewStore.binding(\.$route),
+            unwrapping: viewStore.$route,
             case: /HistoryReducer.Route.detail,
             isEnabled: DeviceUtil.isPad
         ) { route in
@@ -55,7 +55,7 @@ struct HistoryView: View {
             }
             .autoBlur(radius: blurRadius).environment(\.inSheet, true).navigationViewStyle(.stack)
         }
-        .searchable(text: viewStore.binding(\.$keyword), prompt: L10n.Localizable.Searchable.Prompt.filter)
+        .searchable(text: viewStore.$keyword, prompt: L10n.Localizable.Searchable.Prompt.filter)
         .onAppear {
             if viewStore.galleries.isEmpty {
                 DispatchQueue.main.async {
@@ -70,7 +70,7 @@ struct HistoryView: View {
 
     @ViewBuilder private var navigationLink: some View {
         if DeviceUtil.isPhone {
-            NavigationLink(unwrapping: viewStore.binding(\.$route), case: /HistoryReducer.Route.detail) { route in
+            NavigationLink(unwrapping: viewStore.$route, case: /HistoryReducer.Route.detail) { route in
                 DetailView(
                     store: store.scope(state: \.detailState, action: HistoryReducer.Action.detail),
                     gid: route.wrappedValue, user: user, setting: $setting,
@@ -89,7 +89,7 @@ struct HistoryView: View {
             .disabled(viewStore.loadingState != .idle || viewStore.galleries.isEmpty)
             .confirmationDialog(
                 message: L10n.Localizable.ConfirmationDialog.Title.clear,
-                unwrapping: viewStore.binding(\.$route),
+                unwrapping: viewStore.$route,
                 case: /HistoryReducer.Route.clearHistory
             ) {
                 Button(L10n.Localizable.ConfirmationDialog.Button.clear, role: .destructive) {

--- a/EhPanda/View/Home/History/HistoryView.swift
+++ b/EhPanda/View/Home/History/HistoryView.swift
@@ -104,10 +104,9 @@ struct HistoryView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             HistoryView(
-                store: .init(
-                    initialState: .init(),
-                    reducer: HistoryReducer()
-                ),
+                store: .init(initialState: .init()) {
+                    HistoryReducer()
+                },
                 user: .init(),
                 setting: .constant(.init()),
                 blurRadius: 0,

--- a/EhPanda/View/Home/History/HistoryView.swift
+++ b/EhPanda/View/Home/History/HistoryView.swift
@@ -21,7 +21,7 @@ struct HistoryView: View {
         user: User, setting: Binding<Setting>, blurRadius: Double, tagTranslator: TagTranslator
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.user = user
         _setting = setting
         self.blurRadius = blurRadius

--- a/EhPanda/View/Home/HomeReducer.swift
+++ b/EhPanda/View/Home/HomeReducer.swift
@@ -10,7 +10,7 @@ import Kingfisher
 import UIImageColors
 import ComposableArchitecture
 
-struct HomeReducer: ReducerProtocol {
+struct HomeReducer: Reducer {
     enum Route: Equatable, Hashable {
         case detail(String)
         case misc(HomeMiscGridType)
@@ -93,7 +93,7 @@ struct HomeReducer: ReducerProtocol {
     @Dependency(\.databaseClient) private var databaseClient
     @Dependency(\.libraryClient) private var libraryClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Home/HomeReducer.swift
+++ b/EhPanda/View/Home/HomeReducer.swift
@@ -105,9 +105,10 @@ struct HomeReducer: Reducer {
                 guard state.cardPageIndex < state.popularGalleries.count else { return .none }
                 state.currentCardID = state.popularGalleries[state.cardPageIndex].gid
                 state.allowsCardHitTesting = false
-                return Effect.send(.setAllowsCardHitTesting(true))
-                    .delay(for: .milliseconds(300), scheduler: DispatchQueue.main)
-                    .eraseToEffect()
+                return Effect.publisher {
+                    Effect.send(.setAllowsCardHitTesting(true))
+                        .delay(for: .milliseconds(300), scheduler: DispatchQueue.main)
+                }
 
             case .binding:
                 return .none

--- a/EhPanda/View/Home/HomeReducer.swift
+++ b/EhPanda/View/Home/HomeReducer.swift
@@ -145,7 +145,7 @@ struct HomeReducer: ReducerProtocol {
             case .fetchAllToplistsGalleries:
                 return .merge(
                     ToplistsType.allCases.map({ Action.fetchToplistsGalleries($0.categoryIndex) })
-                        .map(EffectTask<Action>.init)
+                        .map(Effect<Action>.init)
                 )
 
             case .fetchPopularGalleries:

--- a/EhPanda/View/Home/HomeReducer.swift
+++ b/EhPanda/View/Home/HomeReducer.swift
@@ -99,13 +99,13 @@ struct HomeReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? .init(value: .clearSubStates) : .none
+                return state.route == nil ? Effect.send(.clearSubStates) : .none
 
             case .binding(\.$cardPageIndex):
                 guard state.cardPageIndex < state.popularGalleries.count else { return .none }
                 state.currentCardID = state.popularGalleries[state.cardPageIndex].gid
                 state.allowsCardHitTesting = false
-                return .init(value: .setAllowsCardHitTesting(true))
+                return Effect.send(.setAllowsCardHitTesting(true))
                     .delay(for: .milliseconds(300), scheduler: DispatchQueue.main)
                     .eraseToEffect()
 
@@ -114,7 +114,7 @@ struct HomeReducer: Reducer {
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? .init(value: .clearSubStates) : .none
+                return route == nil ? Effect.send(.clearSubStates) : .none
 
             case .clearSubStates:
                 state.frontpageState = .init()
@@ -124,11 +124,11 @@ struct HomeReducer: Reducer {
                 state.historyState = .init()
                 state.detailState = .init()
                 return .merge(
-                    .init(value: .frontpage(.teardown)),
-                    .init(value: .toplists(.teardown)),
-                    .init(value: .popular(.teardown)),
-                    .init(value: .watched(.teardown)),
-                    .init(value: .detail(.teardown))
+                    Effect.send(.frontpage(.teardown)),
+                    Effect.send(.toplists(.teardown)),
+                    Effect.send(.popular(.teardown)),
+                    Effect.send(.watched(.teardown)),
+                    Effect.send(.detail(.teardown))
                 )
 
             case .setAllowsCardHitTesting(let isAllowed):
@@ -137,9 +137,9 @@ struct HomeReducer: Reducer {
 
             case .fetchAllGalleries:
                 return .merge(
-                    .init(value: .fetchPopularGalleries),
-                    .init(value: .fetchFrontpageGalleries),
-                    .init(value: .fetchAllToplistsGalleries)
+                    Effect.send(.fetchPopularGalleries),
+                    Effect.send(.fetchFrontpageGalleries),
+                    Effect.send(.fetchAllToplistsGalleries)
                 )
 
             case .fetchAllToplistsGalleries:

--- a/EhPanda/View/Home/HomeView.swift
+++ b/EhPanda/View/Home/HomeView.swift
@@ -24,7 +24,7 @@ struct HomeView: View {
         user: User, setting: Binding<Setting>, blurRadius: Double, tagTranslator: TagTranslator
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.user = user
         _setting = setting
         self.blurRadius = blurRadius

--- a/EhPanda/View/Home/HomeView.swift
+++ b/EhPanda/View/Home/HomeView.swift
@@ -40,7 +40,7 @@ struct HomeView: View {
                         if !viewStore.popularGalleries.isEmpty {
                             CardSlideSection(
                                 galleries: viewStore.popularGalleries,
-                                pageIndex: viewStore.binding(\.$cardPageIndex),
+                                pageIndex: viewStore.$cardPageIndex,
                                 currentID: viewStore.currentCardID,
                                 colors: viewStore.cardColors,
                                 navigateAction: navigateTo(gid:),
@@ -88,7 +88,7 @@ struct HomeView: View {
                 .zIndex(1)
             }
             .sheet(
-                unwrapping: viewStore.binding(\.$route),
+                unwrapping: viewStore.$route,
                 case: /HomeReducer.Route.detail,
                 isEnabled: DeviceUtil.isPad
             ) { route in
@@ -136,7 +136,7 @@ private extension HomeView {
         sectionLink
     }
     var detailViewLink: some View {
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /HomeReducer.Route.detail) { route in
+        NavigationLink(unwrapping: viewStore.$route, case: /HomeReducer.Route.detail) { route in
             DetailView(
                 store: store.scope(state: \.detailState, action: HomeReducer.Action.detail),
                 gid: route.wrappedValue, user: user, setting: $setting,
@@ -145,7 +145,7 @@ private extension HomeView {
         }
     }
     var miscGridLink: some View {
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /HomeReducer.Route.misc) { route in
+        NavigationLink(unwrapping: viewStore.$route, case: /HomeReducer.Route.misc) { route in
             switch route.wrappedValue {
             case .popular:
                 PopularView(
@@ -166,7 +166,7 @@ private extension HomeView {
         }
     }
     var sectionLink: some View {
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /HomeReducer.Route.section) { route in
+        NavigationLink(unwrapping: viewStore.$route, case: /HomeReducer.Route.section) { route in
             switch route.wrappedValue {
             case .frontpage:
                 FrontpageView(

--- a/EhPanda/View/Home/HomeView.swift
+++ b/EhPanda/View/Home/HomeView.swift
@@ -519,10 +519,9 @@ enum HomeSectionType: String, CaseIterable, Identifiable {
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
         HomeView(
-            store: .init(
-                initialState: .init(),
-                reducer: HomeReducer()
-            ),
+            store: .init(initialState: .init()) {
+                HomeReducer()
+            },
             user: .init(),
             setting: .constant(.init()),
             blurRadius: 0,

--- a/EhPanda/View/Home/Popular/PopularReducer.swift
+++ b/EhPanda/View/Home/Popular/PopularReducer.swift
@@ -58,19 +58,19 @@ struct PopularReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? .init(value: .clearSubStates) : .none
+                return state.route == nil ? Effect.send(.clearSubStates) : .none
 
             case .binding:
                 return .none
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? .init(value: .clearSubStates) : .none
+                return route == nil ? Effect.send(.clearSubStates) : .none
 
             case .clearSubStates:
                 state.detailState = .init()
                 state.filtersState = .init()
-                return .init(value: .detail(.teardown))
+                return Effect.send(.detail(.teardown))
 
             case .teardown:
                 return .cancel(id: CancelID.fetchGalleries)

--- a/EhPanda/View/Home/Popular/PopularReducer.swift
+++ b/EhPanda/View/Home/Popular/PopularReducer.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 
-struct PopularReducer: ReducerProtocol {
+struct PopularReducer: Reducer {
     enum Route: Equatable {
         case filters
         case detail(String)
@@ -52,7 +52,7 @@ struct PopularReducer: ReducerProtocol {
     @Dependency(\.databaseClient) private var databaseClient
     @Dependency(\.hapticsClient) private var hapticsClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Home/Popular/PopularView.swift
+++ b/EhPanda/View/Home/Popular/PopularView.swift
@@ -41,7 +41,7 @@ struct PopularView: View {
             }
         )
         .sheet(
-            unwrapping: viewStore.binding(\.$route),
+            unwrapping: viewStore.$route,
             case: /PopularReducer.Route.detail,
             isEnabled: DeviceUtil.isPad
         ) { route in
@@ -54,11 +54,11 @@ struct PopularView: View {
             }
             .autoBlur(radius: blurRadius).environment(\.inSheet, true).navigationViewStyle(.stack)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /PopularReducer.Route.filters) { _ in
+        .sheet(unwrapping: viewStore.$route, case: /PopularReducer.Route.filters) { _ in
             FiltersView(store: store.scope(state: \.filtersState, action: PopularReducer.Action.filters))
                 .autoBlur(radius: blurRadius).environment(\.inSheet, true)
         }
-        .searchable(text: viewStore.binding(\.$keyword), prompt: L10n.Localizable.Searchable.Prompt.filter)
+        .searchable(text: viewStore.$keyword, prompt: L10n.Localizable.Searchable.Prompt.filter)
         .onAppear {
             if viewStore.galleries.isEmpty {
                 DispatchQueue.main.async {
@@ -73,7 +73,7 @@ struct PopularView: View {
 
     @ViewBuilder private var navigationLink: some View {
         if DeviceUtil.isPhone {
-            NavigationLink(unwrapping: viewStore.binding(\.$route), case: /PopularReducer.Route.detail) { route in
+            NavigationLink(unwrapping: viewStore.$route, case: /PopularReducer.Route.detail) { route in
                 DetailView(
                     store: store.scope(state: \.detailState, action: PopularReducer.Action.detail),
                     gid: route.wrappedValue, user: user, setting: $setting,

--- a/EhPanda/View/Home/Popular/PopularView.swift
+++ b/EhPanda/View/Home/Popular/PopularView.swift
@@ -21,7 +21,7 @@ struct PopularView: View {
         user: User, setting: Binding<Setting>, blurRadius: Double, tagTranslator: TagTranslator
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.user = user
         _setting = setting
         self.blurRadius = blurRadius

--- a/EhPanda/View/Home/Popular/PopularView.swift
+++ b/EhPanda/View/Home/Popular/PopularView.swift
@@ -95,10 +95,9 @@ struct PopularView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             PopularView(
-                store: .init(
-                    initialState: .init(),
-                    reducer: PopularReducer()
-                ),
+                store: .init(initialState: .init()) {
+                    PopularReducer()
+                },
                 user: .init(),
                 setting: .constant(.init()),
                 blurRadius: 0,

--- a/EhPanda/View/Home/Toplists/ToplistsReducer.swift
+++ b/EhPanda/View/Home/Toplists/ToplistsReducer.swift
@@ -132,7 +132,7 @@ struct ToplistsReducer: Reducer {
                 return .none
 
             case .teardown:
-                return .cancel(ids: CancelID.allCases)
+                return .merge(CancelID.allCases.map(Effect.cancel(id:)))
 
             case .fetchGalleries(let pageNum):
                 guard state.loadingState != .loading else { return .none }

--- a/EhPanda/View/Home/Toplists/ToplistsReducer.swift
+++ b/EhPanda/View/Home/Toplists/ToplistsReducer.swift
@@ -119,13 +119,13 @@ struct ToplistsReducer: Reducer {
                 guard let index = Int(state.jumpPageIndex),
                       let pageNumber = state.pageNumber,
                       index > 0, index <= pageNumber.maximum + 1 else {
-                    return .fireAndForget({ hapticsClient.generateNotificationFeedback(.error) })
+                    return .run(operation: { _ in hapticsClient.generateNotificationFeedback(.error) })
                 }
                 return Effect.send(.fetchGalleries(index - 1))
 
             case .presentJumpPageAlert:
                 state.jumpPageAlertPresented = true
-                return .fireAndForget({ hapticsClient.generateFeedback(.light) })
+                return .run(operation: { _ in hapticsClient.generateFeedback(.light) })
 
             case .setJumpPageAlertFocused(let isFocused):
                 state.jumpPageAlertFocused = isFocused

--- a/EhPanda/View/Home/Toplists/ToplistsReducer.swift
+++ b/EhPanda/View/Home/Toplists/ToplistsReducer.swift
@@ -181,7 +181,7 @@ struct ToplistsReducer: ReducerProtocol {
                     state.rawPageNumber[type] = pageNumber
                     state.insertGalleries(type: type, galleries: galleries)
 
-                    var effects: [EffectTask<Action>] = [
+                    var effects: [Effect<Action>] = [
                         databaseClient.cacheGalleries(galleries).fireAndForget()
                     ]
                     if galleries.isEmpty, pageNumber.hasNextPage() {

--- a/EhPanda/View/Home/Toplists/ToplistsReducer.swift
+++ b/EhPanda/View/Home/Toplists/ToplistsReducer.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 
-struct ToplistsReducer: ReducerProtocol {
+struct ToplistsReducer: Reducer {
     enum Route: Equatable {
         case detail(String)
     }
@@ -85,7 +85,7 @@ struct ToplistsReducer: ReducerProtocol {
     @Dependency(\.databaseClient) private var databaseClient
     @Dependency(\.hapticsClient) private var hapticsClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Home/Toplists/ToplistsView.swift
+++ b/EhPanda/View/Home/Toplists/ToplistsView.swift
@@ -153,10 +153,9 @@ struct ToplistsView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             ToplistsView(
-                store: .init(
-                    initialState: .init(),
-                    reducer: ToplistsReducer()
-                ),
+                store: .init(initialState: .init()) {
+                    ToplistsReducer()
+                },
                 user: .init(),
                 setting: .constant(.init()),
                 blurRadius: 0,

--- a/EhPanda/View/Home/Toplists/ToplistsView.swift
+++ b/EhPanda/View/Home/Toplists/ToplistsView.swift
@@ -21,7 +21,7 @@ struct ToplistsView: View {
         user: User, setting: Binding<Setting>, blurRadius: Double, tagTranslator: TagTranslator
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.user = user
         _setting = setting
         self.blurRadius = blurRadius

--- a/EhPanda/View/Home/Toplists/ToplistsView.swift
+++ b/EhPanda/View/Home/Toplists/ToplistsView.swift
@@ -47,7 +47,7 @@ struct ToplistsView: View {
             }
         )
         .sheet(
-            unwrapping: viewStore.binding(\.$route),
+            unwrapping: viewStore.$route,
             case: /ToplistsReducer.Route.detail,
             isEnabled: DeviceUtil.isPad
         ) { route in
@@ -61,13 +61,13 @@ struct ToplistsView: View {
             .autoBlur(radius: blurRadius).environment(\.inSheet, true).navigationViewStyle(.stack)
         }
         .jumpPageAlert(
-            index: viewStore.binding(\.$jumpPageIndex),
-            isPresented: viewStore.binding(\.$jumpPageAlertPresented),
-            isFocused: viewStore.binding(\.$jumpPageAlertFocused),
+            index: viewStore.$jumpPageIndex,
+            isPresented: viewStore.$jumpPageAlertPresented,
+            isFocused: viewStore.$jumpPageAlertFocused,
             pageNumber: viewStore.pageNumber ?? .init(),
             jumpAction: { viewStore.send(.performJumpPage) }
         )
-        .searchable(text: viewStore.binding(\.$keyword), prompt: L10n.Localizable.Searchable.Prompt.filter)
+        .searchable(text: viewStore.$keyword, prompt: L10n.Localizable.Searchable.Prompt.filter)
         .navigationBarBackButtonHidden(viewStore.jumpPageAlertPresented)
         .animation(.default, value: viewStore.jumpPageAlertPresented)
         .onAppear {
@@ -84,7 +84,7 @@ struct ToplistsView: View {
 
     @ViewBuilder private var navigationLink: some View {
         if DeviceUtil.isPhone {
-            NavigationLink(unwrapping: viewStore.binding(\.$route), case: /ToplistsReducer.Route.detail) { route in
+            NavigationLink(unwrapping: viewStore.$route, case: /ToplistsReducer.Route.detail) { route in
                 DetailView(
                     store: store.scope(state: \.detailState, action: ToplistsReducer.Action.detail),
                     gid: route.wrappedValue, user: user, setting: $setting,

--- a/EhPanda/View/Home/Watched/WatchedReducer.swift
+++ b/EhPanda/View/Home/Watched/WatchedReducer.swift
@@ -92,7 +92,7 @@ struct WatchedReducer: Reducer {
                 return .none
 
             case .teardown:
-                return .cancel(ids: CancelID.allCases)
+                return .merge(CancelID.allCases.map(Effect.cancel(id:)))
 
             case .fetchGalleries(let keyword):
                 guard state.loadingState != .loading else { return .none }

--- a/EhPanda/View/Home/Watched/WatchedReducer.swift
+++ b/EhPanda/View/Home/Watched/WatchedReducer.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 
-struct WatchedReducer: ReducerProtocol {
+struct WatchedReducer: Reducer {
     enum Route: Equatable {
         case filters
         case quickSearch
@@ -64,7 +64,7 @@ struct WatchedReducer: ReducerProtocol {
     @Dependency(\.databaseClient) private var databaseClient
     @Dependency(\.hapticsClient) private var hapticsClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Home/Watched/WatchedReducer.swift
+++ b/EhPanda/View/Home/Watched/WatchedReducer.swift
@@ -141,7 +141,7 @@ struct WatchedReducer: ReducerProtocol {
                     state.pageNumber = pageNumber
                     state.insertGalleries(galleries)
 
-                    var effects: [EffectTask<Action>] = [
+                    var effects: [Effect<Action>] = [
                         databaseClient.cacheGalleries(galleries).fireAndForget()
                     ]
                     if galleries.isEmpty, pageNumber.hasNextPage() {

--- a/EhPanda/View/Home/Watched/WatchedReducer.swift
+++ b/EhPanda/View/Home/Watched/WatchedReducer.swift
@@ -70,22 +70,22 @@ struct WatchedReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? .init(value: .clearSubStates) : .none
+                return state.route == nil ? Effect.send(.clearSubStates) : .none
 
             case .binding:
                 return .none
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? .init(value: .clearSubStates) : .none
+                return route == nil ? Effect.send(.clearSubStates) : .none
 
             case .clearSubStates:
                 state.detailState = .init()
                 state.filtersState = .init()
                 state.quickSearchState = .init()
                 return .merge(
-                    .init(value: .detail(.teardown)),
-                    .init(value: .quickSearch(.teardown))
+                    Effect.send(.detail(.teardown)),
+                    Effect.send(.quickSearch(.teardown))
                 )
 
             case .onNotLoginViewButtonTapped:
@@ -112,7 +112,7 @@ struct WatchedReducer: Reducer {
                     guard !galleries.isEmpty else {
                         state.loadingState = .failed(.notFound)
                         guard pageNumber.hasNextPage() else { return .none }
-                        return .init(value: .fetchMoreGalleries)
+                        return Effect.send(.fetchMoreGalleries)
                     }
                     state.pageNumber = pageNumber
                     state.galleries = galleries
@@ -145,7 +145,7 @@ struct WatchedReducer: Reducer {
                         databaseClient.cacheGalleries(galleries).fireAndForget()
                     ]
                     if galleries.isEmpty, pageNumber.hasNextPage() {
-                        effects.append(.init(value: .fetchMoreGalleries))
+                        effects.append(Effect.send(.fetchMoreGalleries))
                     } else if !galleries.isEmpty {
                         state.loadingState = .idle
                     }

--- a/EhPanda/View/Home/Watched/WatchedView.swift
+++ b/EhPanda/View/Home/Watched/WatchedView.swift
@@ -21,7 +21,7 @@ struct WatchedView: View {
         user: User, setting: Binding<Setting>, blurRadius: Double, tagTranslator: TagTranslator
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.user = user
         _setting = setting
         self.blurRadius = blurRadius

--- a/EhPanda/View/Home/Watched/WatchedView.swift
+++ b/EhPanda/View/Home/Watched/WatchedView.swift
@@ -49,7 +49,7 @@ struct WatchedView: View {
             }
         }
         .sheet(
-            unwrapping: viewStore.binding(\.$route),
+            unwrapping: viewStore.$route,
             case: /WatchedReducer.Route.detail,
             isEnabled: DeviceUtil.isPad
         ) { route in
@@ -62,7 +62,7 @@ struct WatchedView: View {
             }
             .autoBlur(radius: blurRadius).environment(\.inSheet, true).navigationViewStyle(.stack)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /WatchedReducer.Route.quickSearch) { _ in
+        .sheet(unwrapping: viewStore.$route, case: /WatchedReducer.Route.quickSearch) { _ in
             QuickSearchView(
                 store: store.scope(state: \.quickSearchState, action: WatchedReducer.Action.quickSearch)
             ) { keyword in
@@ -72,14 +72,14 @@ struct WatchedView: View {
             .accentColor(setting.accentColor)
             .autoBlur(radius: blurRadius)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /WatchedReducer.Route.filters) { _ in
+        .sheet(unwrapping: viewStore.$route, case: /WatchedReducer.Route.filters) { _ in
             FiltersView(store: store.scope(state: \.filtersState, action: WatchedReducer.Action.filters))
                 .autoBlur(radius: blurRadius).environment(\.inSheet, true)
         }
-        .searchable(text: viewStore.binding(\.$keyword))
+        .searchable(text: viewStore.$keyword)
         .searchSuggestions {
             TagSuggestionView(
-                keyword: viewStore.binding(\.$keyword), translations: tagTranslator.translations,
+                keyword: viewStore.$keyword, translations: tagTranslator.translations,
                 showsImages: setting.showsImagesInTags, isEnabled: setting.showsTagsSearchSuggestion
             )
         }
@@ -100,7 +100,7 @@ struct WatchedView: View {
 
     @ViewBuilder private var navigationLink: some View {
         if DeviceUtil.isPhone {
-            NavigationLink(unwrapping: viewStore.binding(\.$route), case: /WatchedReducer.Route.detail) { route in
+            NavigationLink(unwrapping: viewStore.$route, case: /WatchedReducer.Route.detail) { route in
                 DetailView(
                     store: store.scope(state: \.detailState, action: WatchedReducer.Action.detail),
                     gid: route.wrappedValue, user: user, setting: $setting,

--- a/EhPanda/View/Home/Watched/WatchedView.swift
+++ b/EhPanda/View/Home/Watched/WatchedView.swift
@@ -127,10 +127,9 @@ struct WatchedView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             WatchedView(
-                store: .init(
-                    initialState: .init(),
-                    reducer: WatchedReducer()
-                ),
+                store: .init(initialState: .init()) {
+                    WatchedReducer()
+                },
                 user: .init(),
                 setting: .constant(.init()),
                 blurRadius: 0,

--- a/EhPanda/View/Migration/MigrationReducer.swift
+++ b/EhPanda/View/Migration/MigrationReducer.swift
@@ -55,7 +55,7 @@ struct MigrationReducer: Reducer {
                     return .none
                 } else {
                     state.databaseState = .idle
-                    return .init(value: .onDatabasePreparationSuccess)
+                    return Effect.send(.onDatabasePreparationSuccess)
                 }
 
             case .dropDatabase:
@@ -70,7 +70,7 @@ struct MigrationReducer: Reducer {
                     return .none
                 } else {
                     state.databaseState = .idle
-                    return .init(value: .onDatabasePreparationSuccess)
+                    return Effect.send(.onDatabasePreparationSuccess)
                 }
             }
         }

--- a/EhPanda/View/Migration/MigrationReducer.swift
+++ b/EhPanda/View/Migration/MigrationReducer.swift
@@ -60,9 +60,11 @@ struct MigrationReducer: Reducer {
 
             case .dropDatabase:
                 state.databaseState = .loading
-                return databaseClient.dropDatabase()
-                    .delay(for: .milliseconds(500), scheduler: DispatchQueue.main)
-                    .eraseToEffect().map(Action.dropDatabaseDone)
+                return Effect.publisher {
+                    databaseClient.dropDatabase()
+                        .delay(for: .milliseconds(500), scheduler: DispatchQueue.main)
+                        .map(Action.dropDatabaseDone)
+                }
 
             case .dropDatabaseDone(let appError):
                 if let appError {

--- a/EhPanda/View/Migration/MigrationReducer.swift
+++ b/EhPanda/View/Migration/MigrationReducer.swift
@@ -8,7 +8,7 @@
 import Foundation
 import ComposableArchitecture
 
-struct MigrationReducer: ReducerProtocol {
+struct MigrationReducer: Reducer {
     enum Route: Equatable {
         case dropDialog
     }
@@ -31,7 +31,7 @@ struct MigrationReducer: ReducerProtocol {
 
     @Dependency(\.databaseClient) private var databaseClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Migration/MigrationView.swift
+++ b/EhPanda/View/Migration/MigrationView.swift
@@ -36,7 +36,7 @@ struct MigrationView: View {
                     }
                     .confirmationDialog(
                         message: L10n.Localizable.ConfirmationDialog.Title.dropDatabase,
-                        unwrapping: viewStore.binding(\.$route),
+                        unwrapping: viewStore.$route,
                         case: /MigrationReducer.Route.dropDialog
                     ) {
                         Button(L10n.Localizable.ConfirmationDialog.Button.dropDatabase, role: .destructive) {

--- a/EhPanda/View/Migration/MigrationView.swift
+++ b/EhPanda/View/Migration/MigrationView.swift
@@ -54,10 +54,9 @@ struct MigrationView: View {
 struct MigrationView_Previews: PreviewProvider {
     static var previews: some View {
         MigrationView(
-            store: .init(
-                initialState: .init(),
-                reducer: MigrationReducer()
-            )
+            store: .init(initialState: .init()) {
+                MigrationReducer()
+            }
         )
     }
 }

--- a/EhPanda/View/Migration/MigrationView.swift
+++ b/EhPanda/View/Migration/MigrationView.swift
@@ -19,7 +19,7 @@ struct MigrationView: View {
 
     init(store: StoreOf<MigrationReducer>) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
     }
 
     var body: some View {

--- a/EhPanda/View/Reading/ReadingReducer.swift
+++ b/EhPanda/View/Reading/ReadingReducer.swift
@@ -323,7 +323,7 @@ struct ReadingReducer: Reducer {
 
             case .teardown:
                 var effects: [Effect<Action>] = [
-                    .cancel(ids: CancelID.allCases)
+                    .merge(CancelID.allCases.map(Effect.cancel(id:)))
                 ]
                 if !deviceClient.isPad() {
                     effects.append(Effect.send(.setOrientationPortrait(true)))

--- a/EhPanda/View/Reading/ReadingReducer.swift
+++ b/EhPanda/View/Reading/ReadingReducer.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import TTProgressHUD
 import ComposableArchitecture
 
-struct ReadingReducer: ReducerProtocol {
+struct ReadingReducer: Reducer {
     enum Route: Equatable {
         case hud
         case share(ShareItem)
@@ -184,7 +184,7 @@ struct ReadingReducer: ReducerProtocol {
     @Dependency(\.imageClient) private var imageClient
     @Dependency(\.urlClient) private var urlClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Reading/ReadingReducer.swift
+++ b/EhPanda/View/Reading/ReadingReducer.swift
@@ -204,7 +204,7 @@ struct ReadingReducer: ReducerProtocol {
                 return .none
 
             case .setOrientationPortrait(let isPortrait):
-                var effects = [EffectTask<Action>]()
+                var effects = [Effect<Action>]()
                 if isPortrait {
                     effects.append(appDelegateClient.setPortraitOrientationMask().fireAndForget())
                     effects.append(appDelegateClient.setPortraitOrientation().fireAndForget())
@@ -217,7 +217,7 @@ struct ReadingReducer: ReducerProtocol {
                 return .fireAndForget({ hapticsClient.generateFeedback(.light) })
 
             case .onAppear(let gid, let enablesLandscape):
-                var effects: [EffectTask<Action>] = [
+                var effects: [Effect<Action>] = [
                     .init(value: .fetchDatabaseInfos(gid))
                 ]
                 if enablesLandscape {
@@ -322,7 +322,7 @@ struct ReadingReducer: ReducerProtocol {
                     .fireAndForget()
 
             case .teardown:
-                var effects: [EffectTask<Action>] = [
+                var effects: [Effect<Action>] = [
                     .cancel(ids: CancelID.allCases)
                 ]
                 if !deviceClient.isPad() {
@@ -406,7 +406,7 @@ struct ReadingReducer: ReducerProtocol {
                 }
                 var prefetchImageURLs = [URL]()
                 var fetchImageURLIndices = [Int]()
-                var effects = [EffectTask<Action>]()
+                var effects = [Effect<Action>]()
                 let previousUpperBound = max(index - 2, 1)
                 let previousLowerBound = max(previousUpperBound - prefetchLimit / 2, 1)
                 if previousUpperBound - previousLowerBound > 0 {
@@ -509,7 +509,7 @@ struct ReadingReducer: ReducerProtocol {
             case .refetchNormalImageURLsDone(let index, let result):
                 switch result {
                 case .success(let (imageURLs, response)):
-                    var effects = [EffectTask<Action>]()
+                    var effects = [Effect<Action>]()
                     if let response = response {
                         effects.append(cookieClient.setSkipServer(response: response).fireAndForget())
                     }

--- a/EhPanda/View/Reading/ReadingReducer.swift
+++ b/EhPanda/View/Reading/ReadingReducer.swift
@@ -190,7 +190,7 @@ struct ReadingReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$showsSliderPreview):
-                return .fireAndForget({ hapticsClient.generateFeedback(.soft) })
+                return .run(operation: { _ in hapticsClient.generateFeedback(.soft) })
 
             case .binding:
                 return .none
@@ -214,7 +214,7 @@ struct ReadingReducer: Reducer {
                 return .merge(effects)
 
             case .onPerformDismiss:
-                return .fireAndForget({ hapticsClient.generateFeedback(.light) })
+                return .run(operation: { _ in hapticsClient.generateFeedback(.light) })
 
             case .onAppear(let gid, let enablesLandscape):
                 var effects: [Effect<Action>] = [

--- a/EhPanda/View/Reading/ReadingView.swift
+++ b/EhPanda/View/Reading/ReadingView.swift
@@ -598,10 +598,9 @@ struct ReadingView_Previews: PreviewProvider {
             Text("")
                 .fullScreenCover(isPresented: .constant(true)) {
                     ReadingView(
-                        store: .init(
-                            initialState: .init(gallery: .empty),
-                            reducer: ReadingReducer()
-                        ),
+                        store: .init(initialState: .init(gallery: .empty)) {
+                            ReadingReducer()
+                        },
                         gid: .init(),
                         setting: .constant(.init()),
                         blurRadius: 0

--- a/EhPanda/View/Reading/ReadingView.swift
+++ b/EhPanda/View/Reading/ReadingView.swift
@@ -30,7 +30,7 @@ struct ReadingView: View {
         gid: String, setting: Binding<Setting>, blurRadius: Double
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.gid = gid
         _setting = setting
         self.blurRadius = blurRadius

--- a/EhPanda/View/Reading/ReadingView.swift
+++ b/EhPanda/View/Reading/ReadingView.swift
@@ -67,8 +67,8 @@ struct ReadingView: View {
             .id(viewStore.databaseLoadingState)
             .id(viewStore.forceRefreshID)
             ControlPanel(
-                showsPanel: viewStore.binding(\.$showsPanel),
-                showsSliderPreview: viewStore.binding(\.$showsSliderPreview),
+                showsPanel: viewStore.$showsPanel,
+                showsSliderPreview: viewStore.$showsSliderPreview,
                 sliderValue: $pageHandler.sliderValue, setting: $setting,
                 enablesLiveText: $liveTextHandler.enablesLiveText,
                 autoPlayPolicy: .init(get: { autoPlayHandler.policy }, set: setAutoPlayPolocy),
@@ -81,7 +81,7 @@ struct ReadingView: View {
                 fetchPreviewURLsAction: { viewStore.send(.fetchPreviewURLs($0)) }
             )
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /ReadingReducer.Route.readingSetting) { _ in
+        .sheet(unwrapping: viewStore.$route, case: /ReadingReducer.Route.readingSetting) { _ in
             NavigationView {
                 ReadingSettingView(
                     readingDirection: $setting.readingDirection,
@@ -106,13 +106,13 @@ struct ReadingView: View {
             .accentColor(setting.accentColor).tint(setting.accentColor)
             .autoBlur(radius: blurRadius).navigationViewStyle(.stack)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /ReadingReducer.Route.share) { route in
+        .sheet(unwrapping: viewStore.$route, case: /ReadingReducer.Route.share) { route in
             ActivityView(activityItems: [route.wrappedValue.associatedValue])
                 .accentColor(setting.accentColor).autoBlur(radius: blurRadius)
         }
         .progressHUD(
             config: viewStore.hudConfig,
-            unwrapping: viewStore.binding(\.$route),
+            unwrapping: viewStore.$route,
             case: /ReadingReducer.Route.hud
         )
 

--- a/EhPanda/View/Search/SearchReducer.swift
+++ b/EhPanda/View/Search/SearchReducer.swift
@@ -95,7 +95,7 @@ struct SearchReducer: Reducer {
                 )
 
             case .teardown:
-                return .cancel(ids: CancelID.allCases)
+                return .merge(CancelID.allCases.map(Effect.cancel(id:)))
 
             case .fetchGalleries(let keyword):
                 guard state.loadingState != .loading else { return .none }

--- a/EhPanda/View/Search/SearchReducer.swift
+++ b/EhPanda/View/Search/SearchReducer.swift
@@ -146,7 +146,7 @@ struct SearchReducer: ReducerProtocol {
                     state.pageNumber = pageNumber
                     state.insertGalleries(galleries)
 
-                    var effects: [EffectTask<Action>] = [
+                    var effects: [Effect<Action>] = [
                         databaseClient.cacheGalleries(galleries).fireAndForget()
                     ]
                     if galleries.isEmpty, pageNumber.hasNextPage() {

--- a/EhPanda/View/Search/SearchReducer.swift
+++ b/EhPanda/View/Search/SearchReducer.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 
-struct SearchReducer: ReducerProtocol {
+struct SearchReducer: Reducer {
     enum Route: Equatable {
         case filters
         case quickSearch
@@ -64,7 +64,7 @@ struct SearchReducer: ReducerProtocol {
     @Dependency(\.databaseClient) private var databaseClient
     @Dependency(\.hapticsClient) private var hapticsClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Search/SearchReducer.swift
+++ b/EhPanda/View/Search/SearchReducer.swift
@@ -70,7 +70,7 @@ struct SearchReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? .init(value: .clearSubStates) : .none
+                return state.route == nil ? Effect.send(.clearSubStates) : .none
 
             case .binding(\.$keyword):
                 if !state.keyword.isEmpty {
@@ -83,15 +83,15 @@ struct SearchReducer: Reducer {
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? .init(value: .clearSubStates) : .none
+                return route == nil ? Effect.send(.clearSubStates) : .none
 
             case .clearSubStates:
                 state.detailState = .init()
                 state.filtersState = .init()
                 state.quickSearchState = .init()
                 return .merge(
-                    .init(value: .detail(.teardown)),
-                    .init(value: .quickSearch(.teardown))
+                    Effect.send(.detail(.teardown)),
+                    Effect.send(.quickSearch(.teardown))
                 )
 
             case .teardown:
@@ -117,7 +117,7 @@ struct SearchReducer: Reducer {
                     guard !galleries.isEmpty else {
                         state.loadingState = .failed(.notFound)
                         guard pageNumber.hasNextPage() else { return .none }
-                        return .init(value: .fetchMoreGalleries)
+                        return Effect.send(.fetchMoreGalleries)
                     }
                     state.pageNumber = pageNumber
                     state.galleries = galleries
@@ -150,7 +150,7 @@ struct SearchReducer: Reducer {
                         databaseClient.cacheGalleries(galleries).fireAndForget()
                     ]
                     if galleries.isEmpty, pageNumber.hasNextPage() {
-                        effects.append(.init(value: .fetchMoreGalleries))
+                        effects.append(Effect.send(.fetchMoreGalleries))
                     } else if !galleries.isEmpty {
                         state.loadingState = .idle
                     }

--- a/EhPanda/View/Search/SearchRootReducer.swift
+++ b/EhPanda/View/Search/SearchRootReducer.swift
@@ -94,8 +94,8 @@ struct SearchRootReducer: Reducer {
             case .binding(\.$route):
                 return state.route == nil
                 ? .merge(
-                    .init(value: .clearSubStates),
-                    .init(value: .fetchDatabaseInfos)
+                    Effect.send(.clearSubStates),
+                    Effect.send(.fetchDatabaseInfos)
                 )
                 : .none
 
@@ -106,8 +106,8 @@ struct SearchRootReducer: Reducer {
                 state.route = route
                 return route == nil
                 ? .merge(
-                    .init(value: .clearSubStates),
-                    .init(value: .fetchDatabaseInfos)
+                    Effect.send(.clearSubStates),
+                    Effect.send(.fetchDatabaseInfos)
                 )
                 : .none
 
@@ -121,9 +121,9 @@ struct SearchRootReducer: Reducer {
                 state.filtersState = .init()
                 state.quickSearchState = .init()
                 return .merge(
-                    .init(value: .search(.teardown)),
-                    .init(value: .quickSearch(.teardown)),
-                    .init(value: .detail(.teardown))
+                    Effect.send(.search(.teardown)),
+                    Effect.send(.quickSearch(.teardown)),
+                    Effect.send(.detail(.teardown))
                 )
 
             case .syncHistoryKeywords:
@@ -139,11 +139,11 @@ struct SearchRootReducer: Reducer {
 
             case .appendHistoryKeyword(let keyword):
                 state.appendHistoryKeywords([keyword])
-                return .init(value: .syncHistoryKeywords)
+                return Effect.send(.syncHistoryKeywords)
 
             case .removeHistoryKeyword(let keyword):
                 state.removeHistoryKeyword(keyword)
-                return .init(value: .syncHistoryKeywords)
+                return Effect.send(.syncHistoryKeywords)
 
             case .fetchHistoryGalleries:
                 return databaseClient.fetchHistoryGalleries(fetchLimit: 10).map(Action.fetchHistoryGalleriesDone)
@@ -158,7 +158,7 @@ struct SearchRootReducer: Reducer {
                 } else {
                     state.appendHistoryKeywords([state.searchState.lastKeyword])
                 }
-                return .init(value: .syncHistoryKeywords)
+                return Effect.send(.syncHistoryKeywords)
 
             case .search:
                 return .none

--- a/EhPanda/View/Search/SearchRootReducer.swift
+++ b/EhPanda/View/Search/SearchRootReducer.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 
-struct SearchRootReducer: ReducerProtocol {
+struct SearchRootReducer: Reducer {
     enum Route: Equatable {
         case search
         case filters
@@ -86,7 +86,7 @@ struct SearchRootReducer: ReducerProtocol {
     @Dependency(\.databaseClient) private var databaseClient
     @Dependency(\.hapticsClient) private var hapticsClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Search/SearchRootView.swift
+++ b/EhPanda/View/Search/SearchRootView.swift
@@ -21,7 +21,7 @@ struct SearchRootView: View {
         user: User, setting: Binding<Setting>, blurRadius: Double, tagTranslator: TagTranslator
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.user = user
         _setting = setting
         self.blurRadius = blurRadius

--- a/EhPanda/View/Search/SearchRootView.swift
+++ b/EhPanda/View/Search/SearchRootView.swift
@@ -404,10 +404,9 @@ private struct WrappedKeyword: Hashable {
 struct SearchRootView_Previews: PreviewProvider {
     static var previews: some View {
         SearchRootView(
-            store: .init(
-                initialState: .init(),
-                reducer: SearchRootReducer()
-            ),
+            store: .init(initialState: .init()) {
+                SearchRootReducer()
+            },
             user: .init(),
             setting: .constant(.init()),
             blurRadius: 0,

--- a/EhPanda/View/Search/SearchRootView.swift
+++ b/EhPanda/View/Search/SearchRootView.swift
@@ -45,7 +45,7 @@ struct SearchRootView: View {
                 )
             }
             .sheet(
-                unwrapping: viewStore.binding(\.$route),
+                unwrapping: viewStore.$route,
                 case: /SearchRootReducer.Route.detail,
                 isEnabled: DeviceUtil.isPad
             ) { route in
@@ -58,11 +58,11 @@ struct SearchRootView: View {
                 }
                 .autoBlur(radius: blurRadius).environment(\.inSheet, true).navigationViewStyle(.stack)
             }
-            .sheet(unwrapping: viewStore.binding(\.$route), case: /SearchRootReducer.Route.filters) { _ in
+            .sheet(unwrapping: viewStore.$route, case: /SearchRootReducer.Route.filters) { _ in
                 FiltersView(store: store.scope(state: \.filtersState, action: SearchRootReducer.Action.filters))
                     .autoBlur(radius: blurRadius).environment(\.inSheet, true)
             }
-            .sheet(unwrapping: viewStore.binding(\.$route), case: /SearchRootReducer.Route.quickSearch) { _ in
+            .sheet(unwrapping: viewStore.$route, case: /SearchRootReducer.Route.quickSearch) { _ in
                 QuickSearchView(
                     store: store.scope(state: \.quickSearchState, action: SearchRootReducer.Action.quickSearch)
                 ) { keyword in
@@ -75,10 +75,10 @@ struct SearchRootView: View {
                 .accentColor(setting.accentColor)
                 .autoBlur(radius: blurRadius)
             }
-            .searchable(text: viewStore.binding(\.$keyword))
+            .searchable(text: viewStore.$keyword)
             .searchSuggestions {
                 TagSuggestionView(
-                    keyword: viewStore.binding(\.$keyword), translations: tagTranslator.translations,
+                    keyword: viewStore.$keyword, translations: tagTranslator.translations,
                     showsImages: setting.showsImagesInTags, isEnabled: setting.showsTagsSearchSuggestion
                 )
             }
@@ -117,7 +117,7 @@ private extension SearchRootView {
         searchViewLink
     }
     var detailViewLink: some View {
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /SearchRootReducer.Route.detail) { route in
+        NavigationLink(unwrapping: viewStore.$route, case: /SearchRootReducer.Route.detail) { route in
             DetailView(
                 store: store.scope(state: \.detailState, action: SearchRootReducer.Action.detail),
                 gid: route.wrappedValue, user: user, setting: $setting,
@@ -126,7 +126,7 @@ private extension SearchRootView {
         }
     }
     var searchViewLink: some View {
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /SearchRootReducer.Route.search) { _ in
+        NavigationLink(unwrapping: viewStore.$route, case: /SearchRootReducer.Route.search) { _ in
             SearchView(
                 store: store.scope(state: \.searchState, action: SearchRootReducer.Action.search),
                 keyword: viewStore.keyword, user: user, setting: $setting,

--- a/EhPanda/View/Search/SearchView.swift
+++ b/EhPanda/View/Search/SearchView.swift
@@ -122,10 +122,9 @@ struct SearchView: View {
 struct SearchView_Previews: PreviewProvider {
     static var previews: some View {
         SearchView(
-            store: .init(
-                initialState: .init(),
-                reducer: SearchReducer()
-            ),
+            store: .init(initialState: .init()) {
+                SearchReducer()
+            },
             keyword: .init(),
             user: .init(),
             setting: .constant(.init()),

--- a/EhPanda/View/Search/SearchView.swift
+++ b/EhPanda/View/Search/SearchView.swift
@@ -22,7 +22,7 @@ struct SearchView: View {
         keyword: String, user: User, setting: Binding<Setting>, blurRadius: Double, tagTranslator: TagTranslator
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.keyword = keyword
         self.user = user
         _setting = setting

--- a/EhPanda/View/Search/SearchView.swift
+++ b/EhPanda/View/Search/SearchView.swift
@@ -45,7 +45,7 @@ struct SearchView: View {
             }
         )
         .sheet(
-            unwrapping: viewStore.binding(\.$route),
+            unwrapping: viewStore.$route,
             case: /SearchReducer.Route.detail,
             isEnabled: DeviceUtil.isPad
         ) { route in
@@ -58,7 +58,7 @@ struct SearchView: View {
             }
             .autoBlur(radius: blurRadius).environment(\.inSheet, true).navigationViewStyle(.stack)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /SearchReducer.Route.quickSearch) { _ in
+        .sheet(unwrapping: viewStore.$route, case: /SearchReducer.Route.quickSearch) { _ in
             QuickSearchView(
                 store: store.scope(state: \.quickSearchState, action: SearchReducer.Action.quickSearch)
             ) { keyword in
@@ -68,14 +68,14 @@ struct SearchView: View {
             .accentColor(setting.accentColor)
             .autoBlur(radius: blurRadius)
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /SearchReducer.Route.filters) { _ in
+        .sheet(unwrapping: viewStore.$route, case: /SearchReducer.Route.filters) { _ in
             FiltersView(store: store.scope(state: \.filtersState, action: SearchReducer.Action.filters))
                 .accentColor(setting.accentColor).autoBlur(radius: blurRadius)
         }
-        .searchable(text: viewStore.binding(\.$keyword))
+        .searchable(text: viewStore.$keyword)
         .searchSuggestions {
             TagSuggestionView(
-                keyword: viewStore.binding(\.$keyword), translations: tagTranslator.translations,
+                keyword: viewStore.$keyword, translations: tagTranslator.translations,
                 showsImages: setting.showsImagesInTags, isEnabled: setting.showsTagsSearchSuggestion
             )
         }
@@ -96,7 +96,7 @@ struct SearchView: View {
 
     @ViewBuilder private var navigationLink: some View {
         if DeviceUtil.isPhone {
-            NavigationLink(unwrapping: viewStore.binding(\.$route), case: /SearchReducer.Route.detail) { route in
+            NavigationLink(unwrapping: viewStore.$route, case: /SearchReducer.Route.detail) { route in
                 DetailView(
                     store: store.scope(state: \.detailState, action: SearchReducer.Action.detail),
                     gid: route.wrappedValue, user: user, setting: $setting,

--- a/EhPanda/View/Search/Support/QuickSearchReducer.swift
+++ b/EhPanda/View/Search/Support/QuickSearchReducer.swift
@@ -67,14 +67,14 @@ struct QuickSearchReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? .init(value: .clearSubStates) : .none
+                return state.route == nil ? Effect.send(.clearSubStates) : .none
 
             case .binding:
                 return .none
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? .init(value: .clearSubStates) : .none
+                return route == nil ? Effect.send(.clearSubStates) : .none
 
             case .clearSubStates:
                 state.focusedField = nil
@@ -94,26 +94,26 @@ struct QuickSearchReducer: Reducer {
 
             case .appendWord:
                 state.quickSearchWords.append(state.editingWord)
-                return .init(value: .syncQuickSearchWords)
+                return Effect.send(.syncQuickSearchWords)
 
             case .editWord:
                 if let index = state.quickSearchWords.firstIndex(where: { $0.id == state.editingWord.id }) {
                     state.quickSearchWords[index] = state.editingWord
-                    return .init(value: .syncQuickSearchWords)
+                    return Effect.send(.syncQuickSearchWords)
                 }
                 return .none
 
             case .deleteWord(let word):
                 state.quickSearchWords = state.quickSearchWords.filter({ $0 != word })
-                return .init(value: .syncQuickSearchWords)
+                return Effect.send(.syncQuickSearchWords)
 
             case .deleteWordWithOffsets(let offsets):
                 state.quickSearchWords.remove(atOffsets: offsets)
-                return .init(value: .syncQuickSearchWords)
+                return Effect.send(.syncQuickSearchWords)
 
             case .moveWord(let source, let destination):
                 state.quickSearchWords.move(fromOffsets: source, toOffset: destination)
-                return .init(value: .syncQuickSearchWords)
+                return Effect.send(.syncQuickSearchWords)
 
             case .teardown:
                 return .cancel(id: CancelID.fetchQuickSearchWords)

--- a/EhPanda/View/Search/Support/QuickSearchReducer.swift
+++ b/EhPanda/View/Search/Support/QuickSearchReducer.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import ComposableArchitecture
 
-struct QuickSearchReducer: ReducerProtocol {
+struct QuickSearchReducer: Reducer {
     enum Route: Equatable {
         case newWord
         case editWord
@@ -61,7 +61,7 @@ struct QuickSearchReducer: ReducerProtocol {
 
     @Dependency(\.databaseClient) private var databaseClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Search/Support/QuickSearchView.swift
+++ b/EhPanda/View/Search/Support/QuickSearchView.swift
@@ -202,10 +202,9 @@ extension QuickSearchView {
 struct QuickSearchView_Previews: PreviewProvider {
     static var previews: some View {
         QuickSearchView(
-            store: .init(
-                initialState: .init(),
-                reducer: QuickSearchReducer()
-            ),
+            store: .init(initialState: .init()) {
+                QuickSearchReducer()
+            },
             searchAction: { _ in }
         )
     }

--- a/EhPanda/View/Search/Support/QuickSearchView.swift
+++ b/EhPanda/View/Search/Support/QuickSearchView.swift
@@ -54,7 +54,7 @@ struct QuickSearchView: View {
                         .withArrow(isVisible: !viewStore.isListEditing).padding(5)
                         .confirmationDialog(
                             message: L10n.Localizable.ConfirmationDialog.Title.delete,
-                            unwrapping: viewStore.binding(\.$route),
+                            unwrapping: viewStore.$route,
                             case: /QuickSearchReducer.Route.deleteWord,
                             matching: word
                         ) { route in
@@ -82,8 +82,8 @@ struct QuickSearchView: View {
                     && viewStore.quickSearchWords.isEmpty ? 1 : 0
                 )
             }
-            .synchronize(viewStore.binding(\.$focusedField), $focusedField)
-            .environment(\.editMode, viewStore.binding(\.$listEditMode))
+            .synchronize(viewStore.$focusedField, $focusedField)
+            .environment(\.editMode, viewStore.$listEditMode)
             .animation(.default, value: viewStore.quickSearchWords)
             .animation(.default, value: viewStore.listEditMode)
             .onAppear {
@@ -123,10 +123,10 @@ struct QuickSearchView: View {
         }
     }
     @ViewBuilder private var navigationLinks: some View {
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /QuickSearchReducer.Route.newWord) { _ in
+        NavigationLink(unwrapping: viewStore.$route, case: /QuickSearchReducer.Route.newWord) { _ in
             EditWordView(
                 title: L10n.Localizable.QuickSearchView.Title.newWord,
-                word: viewStore.binding(\.$editingWord),
+                word: viewStore.$editingWord,
                 focusedField: $focusedField,
                 submitAction: onTextFieldSubmitted,
                 confirmAction: {
@@ -135,10 +135,10 @@ struct QuickSearchView: View {
                 }
             )
         }
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /QuickSearchReducer.Route.editWord) { _ in
+        NavigationLink(unwrapping: viewStore.$route, case: /QuickSearchReducer.Route.editWord) { _ in
             EditWordView(
                 title: L10n.Localizable.QuickSearchView.Title.editWord,
-                word: viewStore.binding(\.$editingWord),
+                word: viewStore.$editingWord,
                 focusedField: $focusedField,
                 submitAction: onTextFieldSubmitted,
                 confirmAction: {

--- a/EhPanda/View/Search/Support/QuickSearchView.swift
+++ b/EhPanda/View/Search/Support/QuickSearchView.swift
@@ -17,7 +17,7 @@ struct QuickSearchView: View {
 
     init(store: StoreOf<QuickSearchReducer>, searchAction: @escaping (String) -> Void) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.searchAction = searchAction
     }
 

--- a/EhPanda/View/Setting/AccountSetting/AccountSettingReducer.swift
+++ b/EhPanda/View/Setting/AccountSetting/AccountSettingReducer.swift
@@ -9,7 +9,7 @@ import Foundation
 import TTProgressHUD
 import ComposableArchitecture
 
-struct AccountSettingReducer: ReducerProtocol {
+struct AccountSettingReducer: Reducer {
     enum Route: Equatable {
         case hud
         case login
@@ -43,7 +43,7 @@ struct AccountSettingReducer: ReducerProtocol {
     @Dependency(\.cookieClient) private var cookieClient
     @Dependency(\.hapticsClient) private var hapticsClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Setting/AccountSetting/AccountSettingReducer.swift
+++ b/EhPanda/View/Setting/AccountSetting/AccountSettingReducer.swift
@@ -85,7 +85,7 @@ struct AccountSettingReducer: Reducer {
                 return .merge(
                     .send(.setNavigation(.hud)),
                     clipboardClient.saveText(cookiesDescription).fireAndForget(),
-                    .fireAndForget({ hapticsClient.generateNotificationFeedback(.success) })
+                    .run(operation: { _ in hapticsClient.generateNotificationFeedback(.success) })
                 )
 
             case .login(.loginDone):

--- a/EhPanda/View/Setting/AccountSetting/AccountSettingView.swift
+++ b/EhPanda/View/Setting/AccountSetting/AccountSettingView.swift
@@ -222,10 +222,9 @@ struct AccountSettingView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             AccountSettingView(
-                store: .init(
-                    initialState: .init(),
-                    reducer: AccountSettingReducer()
-                ),
+                store: .init(initialState: .init()) {
+                    AccountSettingReducer()
+                },
                 galleryHost: .constant(.ehentai),
                 showsNewDawnGreeting: .constant(false),
                 bypassesSNIFiltering: false,

--- a/EhPanda/View/Setting/AccountSetting/AccountSettingView.swift
+++ b/EhPanda/View/Setting/AccountSetting/AccountSettingView.swift
@@ -40,7 +40,7 @@ struct AccountSettingView: View {
                 }
                 .pickerStyle(.segmented)
                 AccountSection(
-                    route: viewStore.binding(\.$route),
+                    route: viewStore.$route,
                     showsNewDawnGreeting: $showsNewDawnGreeting,
                     bypassesSNIFiltering: bypassesSNIFiltering,
                     loginAction: { viewStore.send(.setNavigation(.login)) },
@@ -55,17 +55,17 @@ struct AccountSettingView: View {
                 )
             }
             CookieSection(
-                ehCookiesState: viewStore.binding(\.$ehCookiesState),
-                exCookiesState: viewStore.binding(\.$exCookiesState),
+                ehCookiesState: viewStore.$ehCookiesState,
+                exCookiesState: viewStore.$exCookiesState,
                 copyAction: { viewStore.send(.copyCookies($0)) }
             )
         }
         .progressHUD(
             config: viewStore.hudConfig,
-            unwrapping: viewStore.binding(\.$route),
+            unwrapping: viewStore.$route,
             case: /AccountSettingReducer.Route.hud
         )
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /AccountSettingReducer.Route.webView) { route in
+        .sheet(unwrapping: viewStore.$route, case: /AccountSettingReducer.Route.webView) { route in
             WebView(url: route.wrappedValue)
                 .autoBlur(radius: blurRadius)
         }
@@ -78,13 +78,13 @@ struct AccountSettingView: View {
 // MARK: NavigationLinks
 private extension AccountSettingView {
     @ViewBuilder var navigationLinks: some View {
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /AccountSettingReducer.Route.login) { _ in
+        NavigationLink(unwrapping: viewStore.$route, case: /AccountSettingReducer.Route.login) { _ in
             LoginView(
                 store: store.scope(state: \.loginState, action: AccountSettingReducer.Action.login),
                 bypassesSNIFiltering: bypassesSNIFiltering, blurRadius: blurRadius
             )
         }
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /AccountSettingReducer.Route.ehSetting) { _ in
+        NavigationLink(unwrapping: viewStore.$route, case: /AccountSettingReducer.Route.ehSetting) { _ in
             EhSettingView(
                 store: store.scope(state: \.ehSettingState, action: AccountSettingReducer.Action.ehSetting),
                 bypassesSNIFiltering: bypassesSNIFiltering, blurRadius: blurRadius

--- a/EhPanda/View/Setting/AccountSetting/AccountSettingView.swift
+++ b/EhPanda/View/Setting/AccountSetting/AccountSettingView.swift
@@ -22,7 +22,7 @@ struct AccountSettingView: View {
         bypassesSNIFiltering: Bool, blurRadius: Double
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         _galleryHost = galleryHost
         _showsNewDawnGreeting = showsNewDawnGreeting
         self.bypassesSNIFiltering = bypassesSNIFiltering

--- a/EhPanda/View/Setting/AppearanceSetting/AppearanceSettingReducer.swift
+++ b/EhPanda/View/Setting/AppearanceSetting/AppearanceSettingReducer.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 
-struct AppearanceSettingReducer: ReducerProtocol {
+struct AppearanceSettingReducer: Reducer {
     enum Route {
         case appIcon
     }
@@ -21,7 +21,7 @@ struct AppearanceSettingReducer: ReducerProtocol {
         case setNavigation(Route?)
     }
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Setting/AppearanceSetting/AppearanceSettingView.swift
+++ b/EhPanda/View/Setting/AppearanceSetting/AppearanceSettingView.swift
@@ -228,10 +228,9 @@ struct AppearanceSettingView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             AppearanceSettingView(
-                store: .init(
-                    initialState: .init(),
-                    reducer: AppearanceSettingReducer()
-                ),
+                store: .init(initialState: .init()) {
+                    AppearanceSettingReducer()
+                },
                 preferredColorScheme: .constant(.automatic),
                 accentColor: .constant(.blue),
                 appIconType: .constant(.default),

--- a/EhPanda/View/Setting/AppearanceSetting/AppearanceSettingView.swift
+++ b/EhPanda/View/Setting/AppearanceSetting/AppearanceSettingView.swift
@@ -31,7 +31,7 @@ struct AppearanceSettingView: View {
         displaysJapaneseTitle: Binding<Bool>
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         _preferredColorScheme = preferredColorScheme
         _accentColor = accentColor
         _appIconType = appIconType

--- a/EhPanda/View/Setting/AppearanceSetting/AppearanceSettingView.swift
+++ b/EhPanda/View/Setting/AppearanceSetting/AppearanceSettingView.swift
@@ -107,7 +107,7 @@ struct AppearanceSettingView: View {
     }
 
     private var navigationLink: some View {
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /AppearanceSettingReducer.Route.appIcon) { _ in
+        NavigationLink(unwrapping: viewStore.$route, case: /AppearanceSettingReducer.Route.appIcon) { _ in
             AppIconView(appIconType: $appIconType)
         }
     }

--- a/EhPanda/View/Setting/EhSetting/EhSettingReducer.swift
+++ b/EhPanda/View/Setting/EhSetting/EhSettingReducer.swift
@@ -76,7 +76,7 @@ struct EhSettingReducer: Reducer {
                 .fireAndForget()
 
             case .teardown:
-                return .cancel(ids: CancelID.allCases)
+                return .merge(CancelID.allCases.map(Effect.cancel(id:)))
 
             case .fetchEhSetting:
                 guard state.loadingState != .loading else { return .none }

--- a/EhPanda/View/Setting/EhSetting/EhSettingReducer.swift
+++ b/EhPanda/View/Setting/EhSetting/EhSettingReducer.swift
@@ -8,7 +8,7 @@
 import Foundation
 import ComposableArchitecture
 
-struct EhSettingReducer: ReducerProtocol {
+struct EhSettingReducer: Reducer {
     enum Route: Equatable {
         case webView(URL)
         case deleteProfile
@@ -54,7 +54,7 @@ struct EhSettingReducer: ReducerProtocol {
     @Dependency(\.hapticsClient) private var hapticsClient
     @Dependency(\.cookieClient) private var cookieClient
 
-    public var body: some ReducerProtocol<State, Action> {
+    public var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Setting/EhSetting/EhSettingView.swift
+++ b/EhPanda/View/Setting/EhSetting/EhSettingView.swift
@@ -33,8 +33,8 @@ struct EhSettingView: View {
                     .tint(nil)
             }
             // Using `Binding.init` will crash the app
-            else if let ehSetting = Binding(unwrapping: viewStore.binding(\.$ehSetting)),
-                    let ehProfile = Binding(unwrapping: viewStore.binding(\.$ehProfile))
+            else if let ehSetting = Binding(unwrapping: viewStore.$ehSetting),
+                    let ehProfile = Binding(unwrapping: viewStore.$ehProfile)
             {
                 form(ehSetting: ehSetting, ehProfile: ehProfile)
                     .transition(.opacity.animation(.default))
@@ -50,7 +50,7 @@ struct EhSettingView: View {
                 viewStore.send(.setDefaultProfile(profileSet))
             }
         }
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /EhSettingReducer.Route.webView) { route in
+        .sheet(unwrapping: viewStore.$route, case: /EhSettingReducer.Route.webView) { route in
             WebView(url: route.wrappedValue)
                 .autoBlur(radius: blurRadius)
         }
@@ -62,10 +62,10 @@ struct EhSettingView: View {
         Form {
             Group {
                 EhProfileSection(
-                    route: viewStore.binding(\.$route),
+                    route: viewStore.$route,
                     ehSetting: ehSetting,
                     ehProfile: ehProfile,
-                    editingProfileName: viewStore.binding(\.$editingProfileName),
+                    editingProfileName: viewStore.$editingProfileName,
                     deleteAction: {
                         if let value = viewStore.ehProfile?.value {
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {

--- a/EhPanda/View/Setting/EhSetting/EhSettingView.swift
+++ b/EhPanda/View/Setting/EhSetting/EhSettingView.swift
@@ -1019,10 +1019,9 @@ struct EhSettingView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             EhSettingView(
-                store: .init(
-                    initialState: .init(ehSetting: .empty, ehProfile: .empty, loadingState: .idle),
-                    reducer: EhSettingReducer()
-                ),
+                store: .init(initialState: .init(ehSetting: .empty, ehProfile: .empty, loadingState: .idle)) {
+                    EhSettingReducer()
+                },
                 bypassesSNIFiltering: false,
                 blurRadius: 0
             )

--- a/EhPanda/View/Setting/EhSetting/EhSettingView.swift
+++ b/EhPanda/View/Setting/EhSetting/EhSettingView.swift
@@ -16,7 +16,7 @@ struct EhSettingView: View {
 
     init(store: StoreOf<EhSettingReducer>, bypassesSNIFiltering: Bool, blurRadius: Double) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.bypassesSNIFiltering = bypassesSNIFiltering
         self.blurRadius = blurRadius
     }

--- a/EhPanda/View/Setting/GeneralSetting/GeneralSettingReducer.swift
+++ b/EhPanda/View/Setting/GeneralSetting/GeneralSettingReducer.swift
@@ -53,18 +53,18 @@ struct GeneralSettingReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? .init(value: .clearSubStates) : .none
+                return state.route == nil ? Effect.send(.clearSubStates) : .none
 
             case .binding:
                 return .none
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? .init(value: .clearSubStates) : .none
+                return route == nil ? Effect.send(.clearSubStates) : .none
 
             case .clearSubStates:
                 state.logsState = .init()
-                return .init(value: .logs(.teardown))
+                return Effect.send(.logs(.teardown))
 
             case .onTranslationsFilePicked:
                 return .none
@@ -76,7 +76,7 @@ struct GeneralSettingReducer: Reducer {
                 return .merge(
                     libraryClient.clearWebImageDiskCache().fireAndForget(),
                     databaseClient.removeImageURLs().fireAndForget(),
-                    .init(value: .calculateWebImageDiskCache)
+                    Effect.send(.calculateWebImageDiskCache)
                 )
 
             case .checkPasscodeSetting:

--- a/EhPanda/View/Setting/GeneralSetting/GeneralSettingReducer.swift
+++ b/EhPanda/View/Setting/GeneralSetting/GeneralSettingReducer.swift
@@ -9,7 +9,7 @@ import Kingfisher
 import LocalAuthentication
 import ComposableArchitecture
 
-struct GeneralSettingReducer: ReducerProtocol {
+struct GeneralSettingReducer: Reducer {
     enum Route {
         case logs
         case clearCache
@@ -47,7 +47,7 @@ struct GeneralSettingReducer: ReducerProtocol {
     @Dependency(\.databaseClient) private var databaseClient
     @Dependency(\.libraryClient) private var libraryClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Setting/GeneralSetting/GeneralSettingView.swift
+++ b/EhPanda/View/Setting/GeneralSetting/GeneralSettingView.swift
@@ -196,10 +196,9 @@ struct GeneralSettingView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             GeneralSettingView(
-                store: .init(
-                    initialState: .init(),
-                    reducer: GeneralSettingReducer()
-                ),
+                store: .init(initialState: .init()) {
+                    GeneralSettingReducer()
+                },
                 tagTranslatorLoadingState: .idle,
                 tagTranslatorEmpty: false,
                 tagTranslatorHasCustomTranslations: false,

--- a/EhPanda/View/Setting/GeneralSetting/GeneralSettingView.swift
+++ b/EhPanda/View/Setting/GeneralSetting/GeneralSettingView.swift
@@ -34,7 +34,7 @@ struct GeneralSettingView: View {
         autoLockPolicy: Binding<AutoLockPolicy>
     ) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.tagTranslatorLoadingState = tagTranslatorLoadingState
         self.tagTranslatorEmpty = tagTranslatorEmpty
         self.tagTranslatorHasCustomTranslations = tagTranslatorHasCustomTranslations

--- a/EhPanda/View/Setting/GeneralSetting/GeneralSettingView.swift
+++ b/EhPanda/View/Setting/GeneralSetting/GeneralSettingView.swift
@@ -106,7 +106,7 @@ struct GeneralSettingView: View {
                     )
                     .confirmationDialog(
                         message: L10n.Localizable.ConfirmationDialog.Title.removeCustomTranslations,
-                        unwrapping: viewStore.binding(\.$route),
+                        unwrapping: viewStore.$route,
                         case: /GeneralSettingReducer.Route.removeCustomTranslations
                     ) {
                         Button(L10n.Localizable.ConfirmationDialog.Button.remove, role: .destructive) {
@@ -164,7 +164,7 @@ struct GeneralSettingView: View {
                 }
                 .confirmationDialog(
                     message: L10n.Localizable.ConfirmationDialog.Title.clear,
-                    unwrapping: viewStore.binding(\.$route),
+                    unwrapping: viewStore.$route,
                     case: /GeneralSettingReducer.Route.clearCache
                 ) {
                     Button(L10n.Localizable.ConfirmationDialog.Button.clear, role: .destructive) {
@@ -186,7 +186,7 @@ struct GeneralSettingView: View {
     }
 
     private var navigationLink: some View {
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /GeneralSettingReducer.Route.logs) { _ in
+        NavigationLink(unwrapping: viewStore.$route, case: /GeneralSettingReducer.Route.logs) { _ in
             LogsView(store: store.scope(state: \.logsState, action: GeneralSettingReducer.Action.logs))
         }
     }

--- a/EhPanda/View/Setting/Login/LoginReducer.swift
+++ b/EhPanda/View/Setting/Login/LoginReducer.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import ComposableArchitecture
 
-struct LoginReducer: ReducerProtocol {
+struct LoginReducer: Reducer {
     private enum CancelID: Hashable {
         case login
     }
@@ -50,7 +50,7 @@ struct LoginReducer: ReducerProtocol {
     @Dependency(\.hapticsClient) private var hapticsClient
     @Dependency(\.cookieClient) private var cookieClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Setting/Login/LoginReducer.swift
+++ b/EhPanda/View/Setting/Login/LoginReducer.swift
@@ -77,7 +77,7 @@ struct LoginReducer: ReducerProtocol {
 
             case .loginDone(let result):
                 state.route = nil
-                var effects = [EffectTask<Action>]()
+                var effects = [Effect<Action>]()
                 if cookieClient.didLogin {
                     state.loginState = .idle
                     effects.append(.fireAndForget({ hapticsClient.generateNotificationFeedback(.success) }))

--- a/EhPanda/View/Setting/Login/LoginReducer.swift
+++ b/EhPanda/View/Setting/Login/LoginReducer.swift
@@ -70,7 +70,7 @@ struct LoginReducer: Reducer {
                 state.focusedField = nil
                 state.loginState = .loading
                 return .merge(
-                    .fireAndForget({ hapticsClient.generateFeedback(.soft) }),
+                    .run(operation: { _ in hapticsClient.generateFeedback(.soft) }),
                     LoginRequest(username: state.username, password: state.password)
                         .effect.map(Action.loginDone).cancellable(id: CancelID.login)
                 )
@@ -80,10 +80,10 @@ struct LoginReducer: Reducer {
                 var effects = [Effect<Action>]()
                 if cookieClient.didLogin {
                     state.loginState = .idle
-                    effects.append(.fireAndForget({ hapticsClient.generateNotificationFeedback(.success) }))
+                    effects.append(.run(operation: { _ in hapticsClient.generateNotificationFeedback(.success) }))
                 } else {
                     state.loginState = .failed(.unknown)
-                    effects.append(.fireAndForget({ hapticsClient.generateNotificationFeedback(.error) }))
+                    effects.append(.run(operation: { _ in hapticsClient.generateNotificationFeedback(.error) }))
                 }
                 if case .success(let response) = result, let response = response {
                     effects.append(cookieClient.setCredentials(response: response).fireAndForget())

--- a/EhPanda/View/Setting/Login/LoginView.swift
+++ b/EhPanda/View/Setting/Login/LoginView.swift
@@ -18,7 +18,7 @@ struct LoginView: View {
 
     init(store: StoreOf<LoginReducer>, bypassesSNIFiltering: Bool, blurRadius: Double) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.bypassesSNIFiltering = bypassesSNIFiltering
         self.blurRadius = blurRadius
     }

--- a/EhPanda/View/Setting/Login/LoginView.swift
+++ b/EhPanda/View/Setting/Login/LoginView.swift
@@ -134,10 +134,9 @@ struct LoginView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             LoginView(
-                store: .init(
-                    initialState: .init(),
-                    reducer: LoginReducer()
-                ),
+                store: .init(initialState: .init()) {
+                    LoginReducer()
+                },
                 bypassesSNIFiltering: false,
                 blurRadius: 0
             )

--- a/EhPanda/View/Setting/Login/LoginView.swift
+++ b/EhPanda/View/Setting/Login/LoginView.swift
@@ -35,11 +35,11 @@ struct LoginView: View {
                 VStack(spacing: 15) {
                     Group {
                         LoginTextField(
-                            focusedField: $focusedField, text: viewStore.binding(\.$username),
+                            focusedField: $focusedField, text: viewStore.$username,
                             description: L10n.Localizable.LoginView.Title.username, isPassword: false
                         )
                         LoginTextField(
-                            focusedField: $focusedField, text: viewStore.binding(\.$password),
+                            focusedField: $focusedField, text: viewStore.$password,
                             description: L10n.Localizable.LoginView.Title.password, isPassword: true
                         )
                     }
@@ -55,8 +55,8 @@ struct LoginView: View {
                 }
             }
         }
-        .synchronize(viewStore.binding(\.$focusedField), $focusedField)
-        .sheet(unwrapping: viewStore.binding(\.$route), case: /LoginReducer.Route.webView) { route in
+        .synchronize(viewStore.$focusedField, $focusedField)
+        .sheet(unwrapping: viewStore.$route, case: /LoginReducer.Route.webView) { route in
             WebView(url: route.wrappedValue) {
                 viewStore.send(.loginDone(.success(nil)))
             }

--- a/EhPanda/View/Setting/Logs/LogsReducer.swift
+++ b/EhPanda/View/Setting/Logs/LogsReducer.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 
-struct LogsReducer: ReducerProtocol {
+struct LogsReducer: Reducer {
     enum Route: Equatable {
         case log(Log)
     }
@@ -37,7 +37,7 @@ struct LogsReducer: ReducerProtocol {
     @Dependency(\.uiApplicationClient) private var uiApplicationClient
     @Dependency(\.fileClient) private var fileClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Setting/Logs/LogsView.swift
+++ b/EhPanda/View/Setting/Logs/LogsView.swift
@@ -175,10 +175,9 @@ struct LogsView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             LogsView(
-                store: .init(
-                    initialState: .init(),
-                    reducer: LogsReducer()
-                )
+                store: .init(initialState: .init()) {
+                    LogsReducer()
+                }
             )
         }
     }

--- a/EhPanda/View/Setting/Logs/LogsView.swift
+++ b/EhPanda/View/Setting/Logs/LogsView.swift
@@ -14,7 +14,7 @@ struct LogsView: View {
 
     init(store: StoreOf<LogsReducer>) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
     }
 
     var body: some View {

--- a/EhPanda/View/Setting/Logs/LogsView.swift
+++ b/EhPanda/View/Setting/Logs/LogsView.swift
@@ -56,7 +56,7 @@ struct LogsView: View {
     }
 
     private var navigationLink: some View {
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /LogsReducer.Route.log) { route in
+        NavigationLink(unwrapping: viewStore.$route, case: /LogsReducer.Route.log) { route in
             LogView(log: route.wrappedValue)
         }
     }

--- a/EhPanda/View/Setting/SettingReducer.swift
+++ b/EhPanda/View/Setting/SettingReducer.swift
@@ -122,7 +122,7 @@ struct SettingReducer: ReducerProtocol {
                 )
 
             case .binding(\.$setting.enablesTagsExtension):
-                var effects: [EffectTask<Action>] = [
+                var effects: [Effect<Action>] = [
                     .init(value: .syncSetting)
                 ]
                 if state.setting.enablesTagsExtension {
@@ -160,7 +160,7 @@ struct SettingReducer: ReducerProtocol {
                 return .init(value: .syncSetting)
 
             case .binding(\.$setting.enablesLandscape):
-                var effects: [EffectTask<Action>] = [
+                var effects: [Effect<Action>] = [
                     .init(value: .syncSetting)
                 ]
                 if !state.setting.enablesLandscape && !deviceClient.isPad() {
@@ -237,7 +237,7 @@ struct SettingReducer: ReducerProtocol {
                 state.setting = appEnv.setting
                 state.tagTranslator = appEnv.tagTranslator
                 state.user = appEnv.user
-                var effects: [EffectTask<Action>] = [
+                var effects: [Effect<Action>] = [
                     .init(value: .syncAppIconType),
                     .init(value: .loadUserSettingsDone),
                     .init(value: .syncUserInterfaceStyle),
@@ -276,7 +276,7 @@ struct SettingReducer: ReducerProtocol {
                 return IgneousRequest().effect.map(Action.fetchIgneousDone)
 
             case .fetchIgneousDone(let result):
-                var effects = [EffectTask<Action>]()
+                var effects = [Effect<Action>]()
                 if case .success(let response) = result {
                     effects.append(cookieClient.setCredentials(response: response).fireAndForget())
                 }
@@ -353,7 +353,7 @@ struct SettingReducer: ReducerProtocol {
                 else { return .none }
                 state.tagTranslatorLoadingState = .loading
 
-                var databaseEffect: EffectTask<Action>?
+                var databaseEffect: Effect<Action>?
                 if state.tagTranslator.language != language {
                     state.tagTranslator = TagTranslator(language: language)
                     databaseEffect = .init(value: .syncTagTranslator)
@@ -383,7 +383,7 @@ struct SettingReducer: ReducerProtocol {
                 return VerifyEhProfileRequest().effect.map(Action.fetchEhProfileIndexDone)
 
             case .fetchEhProfileIndexDone(let result):
-                var effects = [EffectTask<Action>]()
+                var effects = [Effect<Action>]()
 
                 if case .success(let response) = result {
                     if let profileValue = response.profileValue {

--- a/EhPanda/View/Setting/SettingReducer.swift
+++ b/EhPanda/View/Setting/SettingReducer.swift
@@ -8,7 +8,7 @@
 import Foundation
 import ComposableArchitecture
 
-struct SettingReducer: ReducerProtocol {
+struct SettingReducer: Reducer {
     enum Route: Int, Equatable, Hashable, Identifiable, CaseIterable {
         var id: Int { rawValue }
 
@@ -109,7 +109,7 @@ struct SettingReducer: ReducerProtocol {
     @Dependency(\.fileClient) private var fileClient
     @Dependency(\.dfClient) private var dfClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Setting/SettingReducer.swift
+++ b/EhPanda/View/Setting/SettingReducer.swift
@@ -183,7 +183,7 @@ struct SettingReducer: Reducer {
             case .binding(\.$setting.bypassesSNIFiltering):
                 return .merge(
                     Effect.send(.syncSetting),
-                    .fireAndForget({ hapticsClient.generateFeedback(.soft) }),
+                    .run(operation: { _ in hapticsClient.generateFeedback(.soft) }),
                     dfClient.setActive(state.setting.bypassesSNIFiltering).fireAndForget()
                 )
 

--- a/EhPanda/View/Setting/SettingView.swift
+++ b/EhPanda/View/Setting/SettingView.swift
@@ -16,7 +16,7 @@ struct SettingView: View {
 
     init(store: StoreOf<SettingReducer>, blurRadius: Double) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
         self.blurRadius = blurRadius
     }
 

--- a/EhPanda/View/Setting/SettingView.swift
+++ b/EhPanda/View/Setting/SettingView.swift
@@ -183,10 +183,9 @@ extension SettingReducer.Route {
 struct SettingView_Previews: PreviewProvider {
     static var previews: some View {
         SettingView(
-            store: .init(
-                initialState: .init(),
-                reducer: SettingReducer()
-            ),
+            store: .init(initialState: .init()) {
+                SettingReducer()
+            },
             blurRadius: 0
         )
     }

--- a/EhPanda/View/Setting/SettingView.swift
+++ b/EhPanda/View/Setting/SettingView.swift
@@ -42,64 +42,64 @@ struct SettingView: View {
 // MARK: NavigationLinks
 private extension SettingView {
     @ViewBuilder var navigationLinks: some View {
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /SettingReducer.Route.account) { _ in
+        NavigationLink(unwrapping: viewStore.$route, case: /SettingReducer.Route.account) { _ in
             AccountSettingView(
                 store: store.scope(state: \.accountSettingState, action: SettingReducer.Action.account),
-                galleryHost: viewStore.binding(\.$setting.galleryHost),
-                showsNewDawnGreeting: viewStore.binding(\.$setting.showsNewDawnGreeting),
+                galleryHost: viewStore.$setting.galleryHost,
+                showsNewDawnGreeting: viewStore.$setting.showsNewDawnGreeting,
                 bypassesSNIFiltering: viewStore.setting.bypassesSNIFiltering,
                 blurRadius: blurRadius
             )
             .tint(viewStore.setting.accentColor)
         }
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /SettingReducer.Route.general) { _ in
+        NavigationLink(unwrapping: viewStore.$route, case: /SettingReducer.Route.general) { _ in
             GeneralSettingView(
                 store: store.scope(state: \.generalSettingState, action: SettingReducer.Action.general),
                 tagTranslatorLoadingState: viewStore.tagTranslatorLoadingState,
                 tagTranslatorEmpty: viewStore.tagTranslator.translations.isEmpty,
                 tagTranslatorHasCustomTranslations: viewStore.tagTranslator.hasCustomTranslations,
-                enablesTagsExtension: viewStore.binding(\.$setting.enablesTagsExtension),
-                translatesTags: viewStore.binding(\.$setting.translatesTags),
-                showsTagsSearchSuggestion: viewStore.binding(\.$setting.showsTagsSearchSuggestion),
-                showsImagesInTags: viewStore.binding(\.$setting.showsImagesInTags),
-                redirectsLinksToSelectedHost: viewStore.binding(\.$setting.redirectsLinksToSelectedHost),
-                detectsLinksFromClipboard: viewStore.binding(\.$setting.detectsLinksFromClipboard),
-                backgroundBlurRadius: viewStore.binding(\.$setting.backgroundBlurRadius),
-                autoLockPolicy: viewStore.binding(\.$setting.autoLockPolicy)
+                enablesTagsExtension: viewStore.$setting.enablesTagsExtension,
+                translatesTags: viewStore.$setting.translatesTags,
+                showsTagsSearchSuggestion: viewStore.$setting.showsTagsSearchSuggestion,
+                showsImagesInTags: viewStore.$setting.showsImagesInTags,
+                redirectsLinksToSelectedHost: viewStore.$setting.redirectsLinksToSelectedHost,
+                detectsLinksFromClipboard: viewStore.$setting.detectsLinksFromClipboard,
+                backgroundBlurRadius: viewStore.$setting.backgroundBlurRadius,
+                autoLockPolicy: viewStore.$setting.autoLockPolicy
             )
             .tint(viewStore.setting.accentColor)
         }
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /SettingReducer.Route.appearance) { _ in
+        NavigationLink(unwrapping: viewStore.$route, case: /SettingReducer.Route.appearance) { _ in
             AppearanceSettingView(
                 store: store.scope(state: \.appearanceSettingState, action: SettingReducer.Action.appearance),
-                preferredColorScheme: viewStore.binding(\.$setting.preferredColorScheme),
-                accentColor: viewStore.binding(\.$setting.accentColor),
-                appIconType: viewStore.binding(\.$setting.appIconType),
-                listDisplayMode: viewStore.binding(\.$setting.listDisplayMode),
-                showsTagsInList: viewStore.binding(\.$setting.showsTagsInList),
-                listTagsNumberMaximum: viewStore.binding(\.$setting.listTagsNumberMaximum),
-                displaysJapaneseTitle: viewStore.binding(\.$setting.displaysJapaneseTitle)
+                preferredColorScheme: viewStore.$setting.preferredColorScheme,
+                accentColor: viewStore.$setting.accentColor,
+                appIconType: viewStore.$setting.appIconType,
+                listDisplayMode: viewStore.$setting.listDisplayMode,
+                showsTagsInList: viewStore.$setting.showsTagsInList,
+                listTagsNumberMaximum: viewStore.$setting.listTagsNumberMaximum,
+                displaysJapaneseTitle: viewStore.$setting.displaysJapaneseTitle
             )
             .tint(viewStore.setting.accentColor)
         }
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /SettingReducer.Route.reading) { _ in
+        NavigationLink(unwrapping: viewStore.$route, case: /SettingReducer.Route.reading) { _ in
             ReadingSettingView(
-                readingDirection: viewStore.binding(\.$setting.readingDirection),
-                prefetchLimit: viewStore.binding(\.$setting.prefetchLimit),
-                enablesLandscape: viewStore.binding(\.$setting.enablesLandscape),
-                contentDividerHeight: viewStore.binding(\.$setting.contentDividerHeight),
-                maximumScaleFactor: viewStore.binding(\.$setting.maximumScaleFactor),
-                doubleTapScaleFactor: viewStore.binding(\.$setting.doubleTapScaleFactor)
+                readingDirection: viewStore.$setting.readingDirection,
+                prefetchLimit: viewStore.$setting.prefetchLimit,
+                enablesLandscape: viewStore.$setting.enablesLandscape,
+                contentDividerHeight: viewStore.$setting.contentDividerHeight,
+                maximumScaleFactor: viewStore.$setting.maximumScaleFactor,
+                doubleTapScaleFactor: viewStore.$setting.doubleTapScaleFactor
             )
             .tint(viewStore.setting.accentColor)
         }
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /SettingReducer.Route.laboratory) { _ in
+        NavigationLink(unwrapping: viewStore.$route, case: /SettingReducer.Route.laboratory) { _ in
             LaboratorySettingView(
-                bypassesSNIFiltering: viewStore.binding(\.$setting.bypassesSNIFiltering)
+                bypassesSNIFiltering: viewStore.$setting.bypassesSNIFiltering
             )
             .tint(viewStore.setting.accentColor)
         }
-        NavigationLink(unwrapping: viewStore.binding(\.$route), case: /SettingReducer.Route.about) { _ in
+        NavigationLink(unwrapping: viewStore.$route, case: /SettingReducer.Route.about) { _ in
             AboutView().tint(viewStore.setting.accentColor)
         }
     }

--- a/EhPanda/View/Support/FiltersReducer.swift
+++ b/EhPanda/View/Support/FiltersReducer.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 
-struct FiltersReducer: ReducerProtocol {
+struct FiltersReducer: Reducer {
     enum Route {
         case resetFilters
     }
@@ -40,7 +40,7 @@ struct FiltersReducer: ReducerProtocol {
 
     @Dependency(\.databaseClient) private var databaseClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         BindingReducer()
 
         Reduce { state, action in

--- a/EhPanda/View/Support/FiltersReducer.swift
+++ b/EhPanda/View/Support/FiltersReducer.swift
@@ -47,15 +47,15 @@ struct FiltersReducer: Reducer {
             switch action {
             case .binding(\.$searchFilter):
                 state.searchFilter.fixInvalidData()
-                return .init(value: .syncFilter(.search))
+                return Effect.send(.syncFilter(.search))
 
             case .binding(\.$globalFilter):
                 state.globalFilter.fixInvalidData()
-                return .init(value: .syncFilter(.global))
+                return Effect.send(.syncFilter(.global))
 
             case .binding(\.$watchedFilter):
                 state.watchedFilter.fixInvalidData()
-                return .init(value: .syncFilter(.watched))
+                return Effect.send(.syncFilter(.watched))
 
             case .binding:
                 return .none
@@ -91,13 +91,13 @@ struct FiltersReducer: Reducer {
                 switch state.filterRange {
                 case .search:
                     state.searchFilter = .init()
-                    return .init(value: .syncFilter(.search))
+                    return Effect.send(.syncFilter(.search))
                 case .global:
                     state.globalFilter = .init()
-                    return .init(value: .syncFilter(.global))
+                    return Effect.send(.syncFilter(.global))
                 case .watched:
                     state.watchedFilter = .init()
-                    return .init(value: .syncFilter(.watched))
+                    return Effect.send(.syncFilter(.watched))
                 }
 
             case .fetchFilters:

--- a/EhPanda/View/Support/FiltersView.swift
+++ b/EhPanda/View/Support/FiltersView.swift
@@ -22,11 +22,11 @@ struct FiltersView: View {
     private var filter: Binding<Filter> {
         switch viewStore.filterRange {
         case .search:
-            return viewStore.binding(\.$searchFilter)
+            return viewStore.$searchFilter
         case .global:
-            return viewStore.binding(\.$globalFilter)
+            return viewStore.$globalFilter
         case .watched:
-            return viewStore.binding(\.$watchedFilter)
+            return viewStore.$watchedFilter
         }
     }
 
@@ -35,8 +35,8 @@ struct FiltersView: View {
         NavigationView {
             Form {
                 BasicSection(
-                    route: viewStore.binding(\.$route),
-                    filter: filter, filterRange: viewStore.binding(\.$filterRange),
+                    route: viewStore.$route,
+                    filter: filter, filterRange: viewStore.$filterRange,
                     resetFiltersAction: { viewStore.send(.resetFilters) },
                     resetFiltersDialogAction: { viewStore.send(.setNavigation(.resetFilters)) }
                 )
@@ -45,7 +45,7 @@ struct FiltersView: View {
                     submitAction: { viewStore.send(.onTextFieldSubmitted) }
                 )
             }
-            .synchronize(viewStore.binding(\.$focusedBound), $focusedBound)
+            .synchronize(viewStore.$focusedBound, $focusedBound)
             .navigationTitle(L10n.Localizable.FiltersView.Title.filters)
             .onAppear { viewStore.send(.fetchFilters) }
         }

--- a/EhPanda/View/Support/FiltersView.swift
+++ b/EhPanda/View/Support/FiltersView.swift
@@ -16,7 +16,7 @@ struct FiltersView: View {
 
     init(store: StoreOf<FiltersReducer>) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
     }
 
     private var filter: Binding<Filter> {

--- a/EhPanda/View/Support/FiltersView.swift
+++ b/EhPanda/View/Support/FiltersView.swift
@@ -240,10 +240,9 @@ extension FilterRange {
 struct FiltersView_Previews: PreviewProvider {
     static var previews: some View {
         FiltersView(
-            store: .init(
-                initialState: .init(),
-                reducer: FiltersReducer()
-            )
+            store: .init(initialState: .init()) {
+                FiltersReducer()
+            }
         )
     }
 }

--- a/EhPanda/View/TabBar/TabBarReducer.swift
+++ b/EhPanda/View/TabBar/TabBarReducer.swift
@@ -7,7 +7,7 @@
 
 import ComposableArchitecture
 
-struct TabBarReducer: ReducerProtocol {
+struct TabBarReducer: Reducer {
     struct State: Equatable {
         var tabBarItemType: TabBarItemType = .home
     }
@@ -18,7 +18,7 @@ struct TabBarReducer: ReducerProtocol {
 
     @Dependency(\.deviceClient) private var deviceClient
 
-    var body: some ReducerProtocol<State, Action> {
+    var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
             case .setTabBarItemType(let type):

--- a/EhPanda/View/TabBar/TabBarView.swift
+++ b/EhPanda/View/TabBar/TabBarView.swift
@@ -156,10 +156,9 @@ extension TabBarItemType {
 struct TabBarView_Previews: PreviewProvider {
     static var previews: some View {
         TabBarView(
-            store: .init(
-                initialState: .init(),
-                reducer: AppReducer()
-            )
+            store: .init(initialState: .init()) {
+                AppReducer()
+            }
         )
     }
 }

--- a/EhPanda/View/TabBar/TabBarView.swift
+++ b/EhPanda/View/TabBar/TabBarView.swift
@@ -16,7 +16,7 @@ struct TabBarView: View {
 
     init(store: StoreOf<AppReducer>) {
         self.store = store
-        viewStore = ViewStore(store)
+        viewStore = ViewStore(store, observe: { $0 })
     }
 
     var body: some View {


### PR DESCRIPTION
Hi, I want to help migrate to TCA 1.0, but there are many to issues should be fix first.
In this pr, I fix most of the easy to fix issues. Viewing by commit should be clearer to review

---

In each commit:

- [Rename EffectTask with Effect](https://github.com/EhPanda-Team/EhPanda/commit/3d8b320879e43e73ba9e1c269d5e56d8b961d536)
- [Rename ReducerProtocol with Reducer](https://github.com/EhPanda-Team/EhPanda/commit/88fac7436d41eccf5635aad86be8112724fca57c)

Find and replace text

- [Fix 'init(value:)' is deprecated](https://github.com/EhPanda-Team/EhPanda/commit/52fd6c8778805ead21d67154d5d965f9b617aecc)

Replace `Effect.init(value:)` with `Effect.send()`

- [Fix 'fireAndForget' is deprecated](https://github.com/EhPanda-Team/EhPanda/commit/0026c04fbd00d9a834b4ae0079293ddd98cc8ae5)

Replace `Effect.fireAndForget` with `Effect.run()`

- [Fix 'init(initialState:reducer:prepareDependencies:)' is deprecated](https://github.com/EhPanda-Team/EhPanda/commit/90c262a2b7710c3a8572f04e423b184fe4a8542e)

Fix Store init with Reducer in trailing block

- [Fix 'init(_:)' is deprecated](https://github.com/EhPanda-Team/EhPanda/commit/ebb23871e072c1d9874599b37c55f02c805f45d9)

Add observe block in ViewStore init. Use `{ $0 }` because that it is equivalent

- [Fix 'binding(_:fileID:line:)'](https://github.com/EhPanda-Team/EhPanda/commit/253056d6ccd2562e8bc75cedc51dcf03a697dc9f)

Remove using unnecessary .binding function

- [Fix 'eraseToEffect()' is deprecated](https://github.com/EhPanda-Team/EhPanda/commit/53c4574372d5d1dfd838a977553a57d411a2c426)

Remove final call to `eraseToEffect` and wrap inside `Effect.publisher`. However this still won't be compatible with TCA 1.0 but we can fix it later. Because in TCA 1.0 Effect conforms to `Publisher` is deprecated.

- [Fix 'cancel(ids:)' is deprecated](https://github.com/EhPanda-Team/EhPanda/commit/fdbbbc4edc3fc9f6c8ed977a2e75e4e6e16efa39)

Explicitly specify all cases of `CancelID`
