### PR TITLE
Fix most warnings

### DIFF
--- a/EhPanda/App/Tools/Clients/AppDelegateClient.swift
+++ b/EhPanda/App/Tools/Clients/AppDelegateClient.swift
@@ -9,31 +9,27 @@ import SwiftUI
 import ComposableArchitecture
 
 struct AppDelegateClient {
-    let setOrientation: (UIInterfaceOrientationMask) -> Effect<Never>
-    let setOrientationMask: (UIInterfaceOrientationMask) -> Effect<Never>
+    let setOrientation: (UIInterfaceOrientationMask) -> Void
+    let setOrientationMask: (UIInterfaceOrientationMask) -> Void
 }
 
 extension AppDelegateClient {
     static let live: Self = .init(
         setOrientation: { mask in
-            .fireAndForget {
-                DeviceUtil.keyWindow?.windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: mask))
-            }
+            DeviceUtil.keyWindow?.windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: mask))
         },
         setOrientationMask: { mask in
-            .fireAndForget {
-                AppDelegate.orientationMask = mask
-            }
+            AppDelegate.orientationMask = mask
         }
     )
 
-    func setPortraitOrientation() -> Effect<Never> {
+    func setPortraitOrientation() {
         setOrientation(.portrait)
     }
-    func setAllOrientationMask() -> Effect<Never> {
+    func setAllOrientationMask() {
         setOrientationMask([.all])
     }
-    func setPortraitOrientationMask() -> Effect<Never> {
+    func setPortraitOrientationMask() {
         setOrientationMask([.portrait, .portraitUpsideDown])
     }
 }
@@ -55,8 +51,8 @@ extension DependencyValues {
 // MARK: Test
 extension AppDelegateClient {
     static let noop: Self = .init(
-        setOrientation: { _ in .none },
-        setOrientationMask: { _ in .none }
+        setOrientation: { _ in },
+        setOrientationMask: { _ in }
     )
 
     static let unimplemented: Self = .init(

--- a/EhPanda/App/Tools/Clients/ClipboardClient.swift
+++ b/EhPanda/App/Tools/Clients/ClipboardClient.swift
@@ -12,8 +12,8 @@ import UniformTypeIdentifiers
 struct ClipboardClient {
     let url: () -> URL?
     let changeCount: () -> Int
-    let saveText: (String) -> Effect<Never>
-    let saveImage: (UIImage, Bool) -> Effect<Never>
+    let saveText: (String) -> Void
+    let saveImage: (UIImage, Bool) -> Void
 }
 
 extension ClipboardClient {
@@ -29,22 +29,18 @@ extension ClipboardClient {
             UIPasteboard.general.changeCount
         },
         saveText: { text in
-            .run(operation: { _ in
-                UIPasteboard.general.string = text
-            })
+            UIPasteboard.general.string = text
         },
         saveImage: { (image, isAnimated) in
-            .run(operation: { _ in
-                if isAnimated {
-                    DispatchQueue.global(qos: .utility).async {
-                        if let data = image.kf.data(format: .GIF) {
-                            UIPasteboard.general.setData(data, forPasteboardType: UTType.gif.identifier)
-                        }
+            if isAnimated {
+                DispatchQueue.global(qos: .utility).async {
+                    if let data = image.kf.data(format: .GIF) {
+                        UIPasteboard.general.setData(data, forPasteboardType: UTType.gif.identifier)
                     }
-                } else {
-                    UIPasteboard.general.image = image
                 }
-            })
+            } else {
+                UIPasteboard.general.image = image
+            }
         }
     )
 }
@@ -68,8 +64,8 @@ extension ClipboardClient {
     static let noop: Self = .init(
         url: { nil },
         changeCount: { 0 },
-        saveText: { _ in .none },
-        saveImage: { _, _ in .none }
+        saveText: { _ in },
+        saveImage: { _, _ in }
     )
 
     static let unimplemented: Self = .init(

--- a/EhPanda/App/Tools/Clients/CookieClient.swift
+++ b/EhPanda/App/Tools/Clients/CookieClient.swift
@@ -9,7 +9,7 @@ import Foundation
 import ComposableArchitecture
 
 struct CookieClient {
-    let clearAll: () -> Effect<Never>
+    let clearAll: () -> Void
     let getCookie: (URL, String) -> CookieValue
     private let removeCookie: (URL, String) -> Void
     private let checkExistence: (URL, String) -> Bool
@@ -19,13 +19,11 @@ struct CookieClient {
 extension CookieClient {
     static let live: Self = .init(
         clearAll: {
-            .run(operation: { _ in
-                if let historyCookies = HTTPCookieStorage.shared.cookies {
-                    historyCookies.forEach {
-                        HTTPCookieStorage.shared.deleteCookie($0)
-                    }
+            if let historyCookies = HTTPCookieStorage.shared.cookies {
+                historyCookies.forEach {
+                    HTTPCookieStorage.shared.deleteCookie($0)
                 }
-            })
+            }
         },
         getCookie: { url, key in
             var value = CookieValue(
@@ -108,14 +106,12 @@ extension CookieClient {
         guard let cookie = newCookie else { return }
         HTTPCookieStorage.shared.setCookie(cookie)
     }
-    func setOrEditCookie(for url: URL, key: String, value: String) -> Effect<Never> {
-        .run(operation: { _ in
-            if checkExistence(url, key) {
-                editCookie(for: url, key: key, value: value)
-            } else {
-                setCookie(for: url, key: key, value: value)
-            }
-        })
+    func setOrEditCookie(for url: URL, key: String, value: String) {
+        if checkExistence(url, key) {
+            editCookie(for: url, key: key, value: value)
+        } else {
+            setCookie(for: url, key: key, value: value)
+        }
     }
 }
 
@@ -138,35 +134,29 @@ extension CookieClient {
         && !getCookie(url, Defaults.Cookie.ipbPassHash).rawValue.isEmpty
         && getCookie(url, Defaults.Cookie.igneous).rawValue.isEmpty
     }
-    func removeYay() -> Effect<Never> {
-        .run(operation: { _ in
-            removeCookie(Defaults.URL.exhentai, Defaults.Cookie.yay)
-            removeCookie(Defaults.URL.sexhentai, Defaults.Cookie.yay)
-        })
+    func removeYay() {
+        removeCookie(Defaults.URL.exhentai, Defaults.Cookie.yay)
+        removeCookie(Defaults.URL.sexhentai, Defaults.Cookie.yay)
     }
-    func syncExCookies() -> Effect<Never> {
-        .merge(
-            [
-                Defaults.Cookie.ipbMemberId,
-                Defaults.Cookie.ipbPassHash,
-                Defaults.Cookie.igneous
-            ]
-            .map {
-                setOrEditCookie(
-                    for: Defaults.URL.sexhentai,
-                    key: $0,
-                    value: getCookie(Defaults.URL.exhentai, $0).rawValue
-                )
-            }
-        )
+    func syncExCookies() {
+        let cookies = [
+            Defaults.Cookie.ipbMemberId,
+            Defaults.Cookie.ipbPassHash,
+            Defaults.Cookie.igneous
+        ]
+        for cookie in cookies {
+            setOrEditCookie(
+                for: Defaults.URL.sexhentai,
+                key: cookie,
+                value: getCookie(Defaults.URL.exhentai, cookie).rawValue
+            )
+        }
     }
-    func ignoreOffensive() -> Effect<Never> {
-        .merge(
-            setOrEditCookie(for: Defaults.URL.ehentai, key: Defaults.Cookie.ignoreOffensive, value: "1"),
-            setOrEditCookie(for: Defaults.URL.exhentai, key: Defaults.Cookie.ignoreOffensive, value: "1")
-        )
+    func ignoreOffensive() {
+        setOrEditCookie(for: Defaults.URL.ehentai, key: Defaults.Cookie.ignoreOffensive, value: "1")
+        setOrEditCookie(for: Defaults.URL.exhentai, key: Defaults.Cookie.ignoreOffensive, value: "1")
     }
-    func fulfillAnotherHostField() -> Effect<Never> {
+    func fulfillAnotherHostField() {
         let ehURL = Defaults.URL.ehentai
         let exURL = Defaults.URL.exhentai
         let memberIdKey = Defaults.Cookie.ipbMemberId
@@ -177,17 +167,11 @@ extension CookieClient {
         let exPassHash = getCookie(exURL, passHashKey).rawValue
 
         if !ehMemberId.isEmpty && !ehPassHash.isEmpty && (exMemberId.isEmpty || exPassHash.isEmpty) {
-            return .merge(
-                setOrEditCookie(for: exURL, key: memberIdKey, value: ehMemberId),
-                setOrEditCookie(for: exURL, key: passHashKey, value: ehPassHash)
-            )
+            setOrEditCookie(for: exURL, key: memberIdKey, value: ehMemberId)
+            setOrEditCookie(for: exURL, key: passHashKey, value: ehPassHash)
         } else if !exMemberId.isEmpty && !exPassHash.isEmpty && (ehMemberId.isEmpty || ehPassHash.isEmpty) {
-            return .merge(
-                setOrEditCookie(for: ehURL, key: memberIdKey, value: exMemberId),
-                setOrEditCookie(for: ehURL, key: passHashKey, value: exPassHash)
-            )
-        } else {
-            return .none
+            setOrEditCookie(for: ehURL, key: memberIdKey, value: exMemberId)
+            setOrEditCookie(for: ehURL, key: passHashKey, value: exPassHash)
         }
     }
     func loadCookiesState(host: GalleryHost) -> CookiesState {
@@ -218,55 +202,49 @@ extension CookieClient {
 
 // MARK: SetCookies
 extension CookieClient {
-    func setCookies(state: CookiesState, trimsSpaces: Bool = true) -> Effect<Never> {
-        let effects: [Effect<Never>] = state.allCases
-            .flatMap { subState in
-                state.host.cookieURLs
-                    .map {
-                        setOrEditCookie(
-                            for: $0,
-                            key: subState.key,
-                            value: trimsSpaces
-                            ? subState.editingText .trimmingCharacters(in: .whitespaces) : subState.editingText
-                        )
-                    }
+    func setCookies(state: CookiesState, trimsSpaces: Bool = true) {
+        for subState in state.allCases {
+            for cookie in state.host.cookieURLs {
+                setOrEditCookie(
+                    for: cookie,
+                    key: subState.key,
+                    value: trimsSpaces
+                    ? subState.editingText .trimmingCharacters(in: .whitespaces) : subState.editingText
+                )
             }
-        return effects.isEmpty ? .none : .merge(effects)
+        }
+
     }
-    func setCredentials(response: HTTPURLResponse) -> Effect<Never> {
-        .run(operation: { _ in
-            guard let setString = response.allHeaderFields["Set-Cookie"] as? String else { return }
-            setString.components(separatedBy: ", ")
-                .flatMap { $0.components(separatedBy: "; ") }.forEach { value in
-                    [Defaults.URL.ehentai, Defaults.URL.exhentai].forEach { url in
-                        [
-                            Defaults.Cookie.ipbMemberId,
-                            Defaults.Cookie.ipbPassHash,
-                            Defaults.Cookie.igneous
-                        ].forEach { key in
-                            guard !(url == Defaults.URL.ehentai && key == Defaults.Cookie.igneous),
-                                  let range = value.range(of: "\(key)=") else { return }
-                            setCookie(for: url, key: key, value: String(value[range.upperBound...]))
-                        }
+    func setCredentials(response: HTTPURLResponse) {
+        guard let setString = response.allHeaderFields["Set-Cookie"] as? String else { return }
+        setString.components(separatedBy: ", ")
+            .flatMap { $0.components(separatedBy: "; ") }.forEach { value in
+                [Defaults.URL.ehentai, Defaults.URL.exhentai].forEach { url in
+                    [
+                        Defaults.Cookie.ipbMemberId,
+                        Defaults.Cookie.ipbPassHash,
+                        Defaults.Cookie.igneous
+                    ].forEach { key in
+                        guard !(url == Defaults.URL.ehentai && key == Defaults.Cookie.igneous),
+                              let range = value.range(of: "\(key)=") else { return }
+                        setCookie(for: url, key: key, value: String(value[range.upperBound...]))
                     }
                 }
-        })
+            }
     }
-    func setSkipServer(response: HTTPURLResponse) -> Effect<Never> {
-        .run(operation: { _ in
-            guard let setString = response.allHeaderFields["Set-Cookie"] as? String else { return }
-            setString.components(separatedBy: ", ")
-                .flatMap { $0.components(separatedBy: "; ") }
-                .forEach { value in
-                    let key = Defaults.Cookie.skipServer
-                    if let range = value.range(of: "\(key)=") {
-                        setCookie(
-                            for: Defaults.URL.host, key: key,
-                            value: String(value[range.upperBound...]), path: "/s/"
-                        )
-                    }
+    func setSkipServer(response: HTTPURLResponse) {
+        guard let setString = response.allHeaderFields["Set-Cookie"] as? String else { return }
+        setString.components(separatedBy: ", ")
+            .flatMap { $0.components(separatedBy: "; ") }
+            .forEach { value in
+                let key = Defaults.Cookie.skipServer
+                if let range = value.range(of: "\(key)=") {
+                    setCookie(
+                        for: Defaults.URL.host, key: key,
+                        value: String(value[range.upperBound...]), path: "/s/"
+                    )
                 }
-        })
+            }
     }
 }
 
@@ -287,7 +265,7 @@ extension DependencyValues {
 // MARK: Test
 extension CookieClient {
     static let noop: Self = .init(
-        clearAll: { .none },
+        clearAll: {},
         getCookie: { _, _ in .empty },
         removeCookie: { _, _ in },
         checkExistence: { _, _ in false },

--- a/EhPanda/App/Tools/Clients/DFClient.swift
+++ b/EhPanda/App/Tools/Clients/DFClient.swift
@@ -10,23 +10,21 @@ import Kingfisher
 import ComposableArchitecture
 
 struct DFClient {
-    let setActive: (Bool) -> Effect<Never>
+    let setActive: (Bool) -> Void
 }
 
 extension DFClient {
     static let live: Self = .init(
         setActive: { newValue in
-            .run(operation: { _ in
-                if newValue {
-                    URLProtocol.registerClass(DFURLProtocol.self)
-                } else {
-                    URLProtocol.unregisterClass(DFURLProtocol.self)
-                }
-                // Kingfisher
-                let config = KingfisherManager.shared.downloader.sessionConfiguration
-                config.protocolClasses = newValue ? [DFURLProtocol.self] : nil
-                KingfisherManager.shared.downloader.sessionConfiguration = config
-            })
+            if newValue {
+                URLProtocol.registerClass(DFURLProtocol.self)
+            } else {
+                URLProtocol.unregisterClass(DFURLProtocol.self)
+            }
+            // Kingfisher
+            let config = KingfisherManager.shared.downloader.sessionConfiguration
+            config.protocolClasses = newValue ? [DFURLProtocol.self] : nil
+            KingfisherManager.shared.downloader.sessionConfiguration = config
         }
     )
 }
@@ -48,7 +46,7 @@ extension DependencyValues {
 // MARK: Test
 extension DFClient {
     static let noop: Self = .init(
-        setActive: { _ in .none }
+        setActive: { _ in }
     )
 
     static let unimplemented: Self = .init(

--- a/EhPanda/App/Tools/Clients/DatabaseClient.swift
+++ b/EhPanda/App/Tools/Clients/DatabaseClient.swift
@@ -11,8 +11,8 @@ import CoreData
 import ComposableArchitecture
 
 struct DatabaseClient {
-    let prepareDatabase: () -> Effect<AppError?>
-    let dropDatabase: () -> Effect<AppError?>
+    let prepareDatabase: () async -> Result<Void, AppError>
+    let dropDatabase: () async -> Result<Void, AppError>
     private let saveContext: () -> Void
     private let materializedObjects: (NSManagedObjectContext, NSPredicate) -> [NSManagedObject]
 }
@@ -20,35 +20,17 @@ struct DatabaseClient {
 extension DatabaseClient {
     static let live: Self = .init(
         prepareDatabase: {
-            .publisher {
-                Future { promise in
-                    PersistenceController.shared.prepare {
-                        switch $0 {
-                        case .success:
-                            promise(.success(nil))
-
-                        case .failure(let appError):
-                            promise(.success(appError))
-                        }
-                    }
+            await withCheckedContinuation { continuation in
+                PersistenceController.shared.prepare { result in
+                    continuation.resume(returning: result)
                 }
-                .receive(on: DispatchQueue.main)
             }
         },
         dropDatabase: {
-            .publisher {
-                Future { promise in
-                    PersistenceController.shared.rebuild {
-                        switch $0 {
-                        case .success:
-                            promise(.success(nil))
-
-                        case .failure(let appError):
-                            promise(.success(appError))
-                        }
-                    }
+            await withCheckedContinuation { continuation in
+                PersistenceController.shared.rebuild { result in
+                    continuation.resume(returning: result)
                 }
-                .receive(on: DispatchQueue.main)
             }
         },
         saveContext: {
@@ -216,50 +198,27 @@ extension DatabaseClient {
         }
         return entity
     }
-    func fetchAppEnv() -> Effect<AppEnv> {
-        .publisher {
-            Future { promise in
-                DispatchQueue.main.async {
-                    promise(.success(fetchOrCreate(entityType: AppEnvMO.self).toEntity()))
-                }
-            }
-            .receive(on: DispatchQueue.main)
-        }
+    @MainActor func fetchAppEnv() -> AppEnv {
+        fetchOrCreate(entityType: AppEnvMO.self).toEntity()
     }
     func fetchAppEnvSynchronously() -> AppEnv {
         fetchOrCreate(entityType: AppEnvMO.self).toEntity()
     }
-    func fetchGalleryState(gid: String) -> Effect<GalleryState> {
-        guard gid.isValidGID else { return .none }
-        return .publisher {
-            Future { promise in
-                DispatchQueue.main.async {
-                    promise(.success(
-                        fetchOrCreate(entityType: GalleryStateMO.self, gid: gid).toEntity()
-                    ))
-                }
-            }
-            .receive(on: DispatchQueue.main)
-        }
+    @MainActor func fetchGalleryState(gid: String) async -> GalleryState? {
+        guard gid.isValidGID else { return nil }
+        return fetchOrCreate(entityType: GalleryStateMO.self, gid: gid).toEntity()
     }
-    func fetchHistoryGalleries(fetchLimit: Int = 0) -> Effect<[Gallery]> {
-        .publisher {
-            Future { promise in
-                DispatchQueue.main.async {
-                    let predicate = NSPredicate(format: "lastOpenDate != nil")
-                    let sortDescriptor = NSSortDescriptor(
-                        keyPath: \GalleryMO.lastOpenDate, ascending: false
-                    )
-                    let galleries = batchFetch(
-                        entityType: GalleryMO.self, fetchLimit: fetchLimit, predicate: predicate,
-                        findBeforeFetch: false, sortDescriptors: [sortDescriptor]
-                    )
-                    .map { $0.toEntity() }
-                    promise(.success(galleries))
-                }
-            }
-            .receive(on: DispatchQueue.main)
-        }
+    @MainActor func fetchHistoryGalleries(fetchLimit: Int = 0) -> [Gallery] {
+        let predicate = NSPredicate(format: "lastOpenDate != nil")
+        let sortDescriptor = NSSortDescriptor(
+            keyPath: \GalleryMO.lastOpenDate, ascending: false
+        )
+        let galleries = batchFetch(
+            entityType: GalleryMO.self, fetchLimit: fetchLimit, predicate: predicate,
+            findBeforeFetch: false, sortDescriptors: [sortDescriptor]
+        )
+        .map { $0.toEntity() }
+        return galleries
     }
 }
 // MARK: FetchAccessor
@@ -274,200 +233,172 @@ extension DatabaseClient {
             return fetchAppEnvSynchronously().watchedFilter
         }
     }
-    func fetchHistoryKeywords() -> Effect<[String]> {
-        fetchAppEnv().map(\.historyKeywords)
+    @MainActor func fetchHistoryKeywords() -> [String] {
+        fetchAppEnv().historyKeywords
     }
-    func fetchQuickSearchWords() -> Effect<[QuickSearchWord]> {
-        fetchAppEnv().map(\.quickSearchWords)
+    @MainActor func fetchQuickSearchWords() -> [QuickSearchWord] {
+        fetchAppEnv().quickSearchWords
     }
-    func fetchGalleryPreviewURLs(gid: String) -> Effect<[Int: URL]> {
-        guard gid.isValidGID else { return .none }
-        return fetchGalleryState(gid: gid).map(\.previewURLs)
+    @MainActor func fetchGalleryPreviewURLs(gid: String) async -> [Int: URL]? {
+        guard gid.isValidGID else { return nil }
+        return await fetchGalleryState(gid: gid).map(\.previewURLs)
     }
 }
 
 // MARK: UpdateGallery
 extension DatabaseClient {
-    func updateGallery(gid: String, key: String, value: Any?) -> Effect<Never> {
-        guard gid.isValidGID else { return .none }
-        return .run { _ in
-            DispatchQueue.main.async {
-                update(
-                    entityType: GalleryMO.self, gid: gid, createIfNil: true,
-                    commitChanges: { $0.setValue(value, forKeyPath: key) }
-                )
+    @MainActor func updateGallery(gid: String, key: String, value: Any?) {
+        guard gid.isValidGID else { return }
+        update(
+            entityType: GalleryMO.self, gid: gid, createIfNil: true,
+            commitChanges: { $0.setValue(value, forKeyPath: key) }
+        )
+    }
+    @MainActor func updateLastOpenDate(gid: String, date: Date = .now) {
+        guard gid.isValidGID else { return }
+        updateGallery(gid: gid, key: "lastOpenDate", value: date)
+    }
+    @MainActor func clearHistoryGalleries() {
+        let predicate = NSPredicate(format: "lastOpenDate != nil")
+        batchUpdate(entityType: GalleryMO.self, predicate: predicate) { galleryMOs in
+            galleryMOs.forEach { galleryMO in
+                galleryMO.lastOpenDate = nil
             }
         }
     }
-    func updateLastOpenDate(gid: String, date: Date = .now) -> Effect<Never> {
-        guard gid.isValidGID else { return .none }
-        return updateGallery(gid: gid, key: "lastOpenDate", value: date)
-    }
-    func clearHistoryGalleries() -> Effect<Never> {
-        .run(operation: { _ in
-            DispatchQueue.main.async {
-                let predicate = NSPredicate(format: "lastOpenDate != nil")
-                batchUpdate(entityType: GalleryMO.self, predicate: predicate) { galleryMOs in
-                    galleryMOs.forEach { galleryMO in
-                        galleryMO.lastOpenDate = nil
-                    }
+    @MainActor func cacheGalleries(_ galleries: [Gallery]) {
+        for gallery in galleries.filter({ $0.id.isValidGID }) {
+            let storedMO = fetch(
+                entityType: GalleryMO.self, gid: gallery.gid
+            ) { managedObject in
+                managedObject?.category = gallery.category.rawValue
+                managedObject?.coverURL = gallery.coverURL
+                managedObject?.galleryURL = gallery.galleryURL
+                // managedObject?.lastOpenDate = gallery.lastOpenDate
+                managedObject?.pageCount = Int64(gallery.pageCount)
+                managedObject?.postedDate = gallery.postedDate
+                managedObject?.rating = gallery.rating
+                managedObject?.tags = gallery.tags.toData()
+                managedObject?.title = gallery.title
+                managedObject?.token = gallery.token
+                if let uploader = gallery.uploader {
+                    managedObject?.uploader = uploader
                 }
             }
-        })
-    }
-    func cacheGalleries(_ galleries: [Gallery]) -> Effect<Never> {
-        .run(operation: { _ in
-            DispatchQueue.main.async {
-                for gallery in galleries.filter({ $0.id.isValidGID }) {
-                    let storedMO = fetch(
-                        entityType: GalleryMO.self, gid: gallery.gid
-                    ) { managedObject in
-                        managedObject?.category = gallery.category.rawValue
-                        managedObject?.coverURL = gallery.coverURL
-                        managedObject?.galleryURL = gallery.galleryURL
-                        // managedObject?.lastOpenDate = gallery.lastOpenDate
-                        managedObject?.pageCount = Int64(gallery.pageCount)
-                        managedObject?.postedDate = gallery.postedDate
-                        managedObject?.rating = gallery.rating
-                        managedObject?.tags = gallery.tags.toData()
-                        managedObject?.title = gallery.title
-                        managedObject?.token = gallery.token
-                        if let uploader = gallery.uploader {
-                            managedObject?.uploader = uploader
-                        }
-                    }
-                    if storedMO == nil {
-                        gallery.toManagedObject(in: PersistenceController.shared.container.viewContext)
-                    }
-                }
-                saveContext()
+            if storedMO == nil {
+                gallery.toManagedObject(in: PersistenceController.shared.container.viewContext)
             }
-        })
+        }
+        saveContext()
     }
 }
 
 // MARK: UpdateGalleryDetail
 extension DatabaseClient {
-    func cacheGalleryDetail(_ detail: GalleryDetail) -> Effect<Never> {
-        guard detail.gid.isValidGID else { return .none }
-        return .run { _ in
-            DispatchQueue.main.async {
-                let storedMO = fetch(
-                    entityType: GalleryDetailMO.self, gid: detail.gid
-                ) { managedObject in
-                    managedObject?.archiveURL = detail.archiveURL
-                    managedObject?.category = detail.category.rawValue
-                    managedObject?.coverURL = detail.coverURL
-                    managedObject?.isFavorited = detail.isFavorited
-                    managedObject?.visibility = detail.visibility.toData()
-                    managedObject?.jpnTitle = detail.jpnTitle
-                    managedObject?.language = detail.language.rawValue
-                    managedObject?.favoritedCount = Int64(detail.favoritedCount)
-                    managedObject?.pageCount = Int64(detail.pageCount)
-                    managedObject?.parentURL = detail.parentURL
-                    managedObject?.postedDate = detail.postedDate
-                    managedObject?.rating = detail.rating
-                    managedObject?.userRating = detail.userRating
-                    managedObject?.ratingCount = Int64(detail.ratingCount)
-                    managedObject?.sizeCount = detail.sizeCount
-                    managedObject?.sizeType = detail.sizeType
-                    managedObject?.title = detail.title
-                    managedObject?.torrentCount = Int64(detail.torrentCount)
-                    managedObject?.uploader = detail.uploader
-                }
-                if storedMO == nil {
-                    detail.toManagedObject(in: PersistenceController.shared.container.viewContext)
-                }
-                saveContext()
-            }
+    @MainActor func cacheGalleryDetail(_ detail: GalleryDetail) {
+        guard detail.gid.isValidGID else { return }
+        let storedMO = fetch(
+            entityType: GalleryDetailMO.self, gid: detail.gid
+        ) { managedObject in
+            managedObject?.archiveURL = detail.archiveURL
+            managedObject?.category = detail.category.rawValue
+            managedObject?.coverURL = detail.coverURL
+            managedObject?.isFavorited = detail.isFavorited
+            managedObject?.visibility = detail.visibility.toData()
+            managedObject?.jpnTitle = detail.jpnTitle
+            managedObject?.language = detail.language.rawValue
+            managedObject?.favoritedCount = Int64(detail.favoritedCount)
+            managedObject?.pageCount = Int64(detail.pageCount)
+            managedObject?.parentURL = detail.parentURL
+            managedObject?.postedDate = detail.postedDate
+            managedObject?.rating = detail.rating
+            managedObject?.userRating = detail.userRating
+            managedObject?.ratingCount = Int64(detail.ratingCount)
+            managedObject?.sizeCount = detail.sizeCount
+            managedObject?.sizeType = detail.sizeType
+            managedObject?.title = detail.title
+            managedObject?.torrentCount = Int64(detail.torrentCount)
+            managedObject?.uploader = detail.uploader
         }
+        if storedMO == nil {
+            detail.toManagedObject(in: PersistenceController.shared.container.viewContext)
+        }
+        saveContext()
     }
 }
 
 // MARK: UpdateGalleryState
 extension DatabaseClient {
-    func updateGalleryState(gid: String, commitChanges: @escaping (GalleryStateMO) -> Void) -> Effect<Never> {
-        guard gid.isValidGID else { return .none }
-        return .run { _ in
-            DispatchQueue.main.async {
-                update(
-                    entityType: GalleryStateMO.self, gid: gid, createIfNil: true,
-                    commitChanges: commitChanges
-                )
-            }
-        }
+    @MainActor func updateGalleryState(gid: String, commitChanges: @escaping (GalleryStateMO) -> Void) {
+        guard gid.isValidGID else { return }
+        update(
+            entityType: GalleryStateMO.self, gid: gid, createIfNil: true,
+            commitChanges: commitChanges
+        )
     }
-    func updateGalleryState(gid: String, key: String, value: Any?) -> Effect<Never> {
-        guard gid.isValidGID else { return .none }
-        return updateGalleryState(gid: gid) { stateMO in
+    @MainActor func updateGalleryState(gid: String, key: String, value: Any?) {
+        guard gid.isValidGID else { return }
+        updateGalleryState(gid: gid) { stateMO in
             stateMO.setValue(value, forKeyPath: key)
         }
     }
-    func updateGalleryTags(gid: String, tags: [GalleryTag]) -> Effect<Never> {
-        guard gid.isValidGID else { return .none }
-        return updateGalleryState(gid: gid, key: "tags", value: tags.toData())
+    @MainActor func updateGalleryTags(gid: String, tags: [GalleryTag]) {
+        guard gid.isValidGID else { return }
+        updateGalleryState(gid: gid, key: "tags", value: tags.toData())
     }
-    func updatePreviewConfig(gid: String, config: PreviewConfig) -> Effect<Never> {
-        guard gid.isValidGID else { return .none }
-        return updateGalleryState(gid: gid, key: "previewConfig", value: config.toData())
+    @MainActor func updatePreviewConfig(gid: String, config: PreviewConfig) {
+        guard gid.isValidGID else { return }
+        updateGalleryState(gid: gid, key: "previewConfig", value: config.toData())
     }
-    func updateReadingProgress(gid: String, progress: Int) -> Effect<Never> {
-        guard gid.isValidGID else { return .none }
-        return updateGalleryState(gid: gid, key: "readingProgress", value: Int64(progress))
+    @MainActor func updateReadingProgress(gid: String, progress: Int) {
+        guard gid.isValidGID else { return }
+        updateGalleryState(gid: gid, key: "readingProgress", value: Int64(progress))
     }
-    func updateComments(gid: String, comments: [GalleryComment]) -> Effect<Never> {
-        guard gid.isValidGID else { return .none }
-        return updateGalleryState(gid: gid, key: "comments", value: comments.toData())
+    @MainActor func updateComments(gid: String, comments: [GalleryComment]) {
+        guard gid.isValidGID else { return }
+        updateGalleryState(gid: gid, key: "comments", value: comments.toData())
     }
 
-    func removeImageURLs(gid: String) -> Effect<Never> {
-        guard gid.isValidGID else { return .none }
-        return updateGalleryState(gid: gid) { galleryStateMO in
+    @MainActor func removeImageURLs(gid: String) {
+        guard gid.isValidGID else { return }
+        updateGalleryState(gid: gid) { galleryStateMO in
             galleryStateMO.imageURLs = nil
             galleryStateMO.previewURLs = nil
             galleryStateMO.thumbnailURLs = nil
             galleryStateMO.originalImageURLs = nil
         }
     }
-    func removeImageURLs() -> Effect<Never> {
-        .run(operation: { _ in
-            DispatchQueue.main.async {
-                batchUpdate(entityType: GalleryStateMO.self) { galleryStateMOs in
-                    galleryStateMOs.forEach { galleryStateMO in
-                        galleryStateMO.imageURLs = nil
-                        galleryStateMO.previewURLs = nil
-                        galleryStateMO.thumbnailURLs = nil
-                        galleryStateMO.originalImageURLs = nil
-                    }
-                }
+    @MainActor func removeImageURLs() {
+        batchUpdate(entityType: GalleryStateMO.self) { galleryStateMOs in
+            galleryStateMOs.forEach { galleryStateMO in
+                galleryStateMO.imageURLs = nil
+                galleryStateMO.previewURLs = nil
+                galleryStateMO.thumbnailURLs = nil
+                galleryStateMO.originalImageURLs = nil
             }
-        })
+        }
     }
-    func removeExpiredImageURLs() -> Effect<Never> {
+    @MainActor func removeExpiredImageURLs() {
         fetchHistoryGalleries()
-            .map { $0.filter { Date().timeIntervalSince($0.lastOpenDate ?? .distantPast) > .oneWeek } }
-            .map { $0.map { removeImageURLs(gid: $0.id) } }
-            .map(Effect<Never>.merge)
-            .fireAndForget()
+            .filter { Date().timeIntervalSince($0.lastOpenDate ?? .distantPast) > .oneWeek }
+            .forEach { removeImageURLs(gid: $0.id) }
     }
-    func updateThumbnailURLs(gid: String, thumbnailURLs: [Int: URL]) -> Effect<Never> {
-        guard gid.isValidGID else { return .none }
-        return updateGalleryState(gid: gid) { galleryStateMO in
+    @MainActor func updateThumbnailURLs(gid: String, thumbnailURLs: [Int: URL]) {
+        guard gid.isValidGID else { return }
+        updateGalleryState(gid: gid) { galleryStateMO in
             update(gid: gid, storedData: &galleryStateMO.thumbnailURLs, new: thumbnailURLs)
         }
     }
-    func updateImageURLs(
-        gid: String, imageURLs: [Int: URL], originalImageURLs: [Int: URL]
-    ) -> Effect<Never> {
-        guard gid.isValidGID else { return .none }
-        return updateGalleryState(gid: gid) { galleryStateMO in
+    @MainActor func updateImageURLs(gid: String, imageURLs: [Int: URL], originalImageURLs: [Int: URL]) {
+        guard gid.isValidGID else { return }
+        updateGalleryState(gid: gid) { galleryStateMO in
             update(gid: gid, storedData: &galleryStateMO.imageURLs, new: imageURLs)
             update(gid: gid, storedData: &galleryStateMO.originalImageURLs, new: originalImageURLs)
         }
     }
-    func updatePreviewURLs(gid: String, previewURLs: [Int: URL]) -> Effect<Never> {
-        guard gid.isValidGID else { return .none }
-        return updateGalleryState(gid: gid) { galleryStateMO in
+    @MainActor func updatePreviewURLs(gid: String, previewURLs: [Int: URL]) {
+        guard gid.isValidGID else { return }
+        updateGalleryState(gid: gid) { galleryStateMO in
             update(gid: gid, storedData: &galleryStateMO.previewURLs, new: previewURLs)
         }
     }
@@ -489,20 +420,16 @@ extension DatabaseClient {
 
 // MARK: UpdateAppEnv
 extension DatabaseClient {
-    func updateAppEnv(key: String, value: Any?) -> Effect<Never> {
-        .run(operation: { _ in
-            DispatchQueue.main.async {
-                update(
-                    entityType: AppEnvMO.self, createIfNil: true,
-                    commitChanges: { $0.setValue(value, forKeyPath: key) }
-                )
-            }
-        })
+    @MainActor func updateAppEnv(key: String, value: Any?) {
+        update(
+            entityType: AppEnvMO.self, createIfNil: true,
+            commitChanges: { $0.setValue(value, forKeyPath: key) }
+        )
     }
-    func updateSetting(_ setting: Setting) -> Effect<Never> {
+    @MainActor func updateSetting(_ setting: Setting) {
         updateAppEnv(key: "setting", value: setting.toData())
     }
-    func updateFilter(_ filter: Filter, range: FilterRange) -> Effect<Never> {
+    @MainActor func updateFilter(_ filter: Filter, range: FilterRange) {
         let key: String
         switch range {
         case .search:
@@ -512,39 +439,33 @@ extension DatabaseClient {
         case .watched:
             key = "watchedFilter"
         }
-        return updateAppEnv(key: key, value: filter.toData())
+        updateAppEnv(key: key, value: filter.toData())
     }
-    func updateTagTranslator(_ tagTranslator: TagTranslator) -> Effect<Never> {
+    @MainActor func updateTagTranslator(_ tagTranslator: TagTranslator) {
         updateAppEnv(key: "tagTranslator", value: tagTranslator.toData())
     }
-    func updateUser(_ user: User) -> Effect<Never> {
+    @MainActor func updateUser(_ user: User) {
         updateAppEnv(key: "user", value: user.toData())
     }
-    func updateHistoryKeywords(_ keywords: [String]) -> Effect<Never> {
+    @MainActor func updateHistoryKeywords(_ keywords: [String]) {
         updateAppEnv(key: "historyKeywords", value: keywords.toData())
     }
-    func updateQuickSearchWords(_ words: [QuickSearchWord]) -> Effect<Never> {
+    @MainActor func updateQuickSearchWords(_ words: [QuickSearchWord]) {
         updateAppEnv(key: "quickSearchWords", value: words.toData())
     }
 
     // Update User
-    func updateUserProperty(_ commitChanges: @escaping (inout User) -> Void) -> Effect<Never> {
-        .publisher {
-            fetchAppEnv().map(\.user)
-                .map { (user: User) -> User in
-                    var user = user
-                    commitChanges(&user)
-                    return user
-                }
-                .flatMap(updateUser)
-        }
+    @MainActor func updateUserProperty(_ commitChanges: @escaping (inout User) -> Void) {
+        var user = fetchAppEnv().user
+        commitChanges(&user)
+        updateUser(user)
     }
-    func updateGreeting(_ greeting: Greeting) -> Effect<Never> {
+    @MainActor func updateGreeting(_ greeting: Greeting) {
         updateUserProperty { user in
             user.greeting = greeting
         }
     }
-    func updateGalleryFunds(galleryPoints: String, credits: String) -> Effect<Never> {
+    @MainActor func updateGalleryFunds(galleryPoints: String, credits: String) {
         updateUserProperty { user in
             user.credits = credits
             user.galleryPoints = galleryPoints
@@ -569,8 +490,8 @@ extension DependencyValues {
 // MARK: Test
 extension DatabaseClient {
     static let noop: Self = .init(
-        prepareDatabase: { .none },
-        dropDatabase: { .none },
+        prepareDatabase: { .success(()) },
+        dropDatabase: { .success(()) },
         saveContext: {},
         materializedObjects: { _, _ in .init() }
     )

--- a/EhPanda/App/Tools/Clients/ImageClient.swift
+++ b/EhPanda/App/Tools/Clients/ImageClient.swift
@@ -12,78 +12,66 @@ import Kingfisher
 import ComposableArchitecture
 
 struct ImageClient {
-    let prefetchImages: ([URL]) -> Effect<Never>
-    let saveImageToPhotoLibrary: (UIImage, Bool) -> Effect<Bool>
-    let downloadImage: (URL) -> Effect<Result<UIImage, Error>>
-    let retrieveImage: (String) -> Effect<Result<UIImage, Error>>
+    let prefetchImages: ([URL]) -> Void
+    let saveImageToPhotoLibrary: (UIImage, Bool) async -> Bool
+    let downloadImage: (URL) async -> Result<UIImage, Error>
+    let retrieveImage: (String) async -> Result<UIImage, Error>
 }
 
 extension ImageClient {
     static let live: Self = .init(
         prefetchImages: { urls in
-            .run(operation: { _ in
-                ImagePrefetcher(urls: urls).start()
-            })
+            ImagePrefetcher(urls: urls).start()
         },
         saveImageToPhotoLibrary: { (image, isAnimated) in
-            .publisher {
-                Future { promise in
-                    DispatchQueue.global(qos: .utility).async {
-                        if let data = image.kf.data(format: isAnimated ? .GIF : .unknown) {
-                            PHPhotoLibrary.shared().performChanges {
-                                let request = PHAssetCreationRequest.forAsset()
-                                request.addResource(with: .photo, data: data, options: nil)
-                            } completionHandler: { (isSuccess, _) in
-                                promise(.success(isSuccess))
-                            }
-                        } else {
-                            promise(.success(false))
-                        }
+            await withCheckedContinuation { continuation in
+                if let data = image.kf.data(format: isAnimated ? .GIF : .unknown) {
+                    PHPhotoLibrary.shared().performChanges {
+                        let request = PHAssetCreationRequest.forAsset()
+                        request.addResource(with: .photo, data: data, options: nil)
+                    } completionHandler: { (isSuccess, _) in
+                        continuation.resume(returning: isSuccess)
                     }
+                } else {
+                    continuation.resume(returning: false)
                 }
-                .eraseToAnyPublisher()
-                .receive(on: DispatchQueue.main)
             }
         },
         downloadImage: { url in
-            Future { promise in
+            await withCheckedContinuation { continuation in
                 KingfisherManager.shared.downloader.downloadImage(with: url, options: nil) { result in
                     switch result {
                     case .success(let result):
-                        promise(.success(result.image))
+                        continuation.resume(returning: .success(result.image))
                     case .failure(let error):
-                        promise(.failure(error))
+                        continuation.resume(returning: .failure(error))
                     }
                 }
             }
-            .eraseToAnyPublisher()
-            .catchToEffect()
         },
         retrieveImage: { key in
-            Future { promise in
+            await withCheckedContinuation { continuation in
                 KingfisherManager.shared.cache.retrieveImage(forKey: key) { result in
                     switch result {
                     case .success(let result):
                         if let image = result.image {
-                            promise(.success(image))
+                            continuation.resume(returning: .success(image))
                         } else {
-                            promise(.failure(AppError.notFound))
+                            continuation.resume(returning: .failure(AppError.notFound))
                         }
                     case .failure(let error):
-                        promise(.failure(error))
+                        continuation.resume(returning: .failure(error))
                     }
                 }
             }
-            .eraseToAnyPublisher()
-            .catchToEffect()
         }
     )
 
-    func fetchImage(url: URL) -> Effect<Result<UIImage, Error>> {
+    func fetchImage(url: URL) async -> Result<UIImage, Error> {
         if KingfisherManager.shared.cache.isCached(forKey: url.absoluteString) {
-            return retrieveImage(url.absoluteString)
+            return await retrieveImage(url.absoluteString)
         } else {
-            return downloadImage(url)
+            return await downloadImage(url)
         }
     }
 }
@@ -122,10 +110,10 @@ extension DependencyValues {
 // MARK: Test
 extension ImageClient {
     static let noop: Self = .init(
-        prefetchImages: { _ in .none },
-        saveImageToPhotoLibrary: { _, _ in .none },
-        downloadImage: { _ in .none },
-        retrieveImage: { _ in .none }
+        prefetchImages: { _ in },
+        saveImageToPhotoLibrary: { _, _ in false },
+        downloadImage: { _ in .success(UIImage()) },
+        retrieveImage: { _ in .success(UIImage()) }
     )
 
     static let unimplemented: Self = .init(

--- a/EhPanda/App/Tools/Clients/LoggerClient.swift
+++ b/EhPanda/App/Tools/Clients/LoggerClient.swift
@@ -8,21 +8,17 @@
 import ComposableArchitecture
 
 struct LoggerClient {
-    let info: (Any, Any?) -> Effect<Never>
-    let error: (Any, Any?) -> Effect<Never>
+    let info: (Any, Any?) -> Void
+    let error: (Any, Any?) -> Void
 }
 
 extension LoggerClient {
     static let live: Self = .init(
         info: { message, context in
-            .run(operation: { _ in
-                Logger.info(message, context: context)
-            })
+            Logger.info(message, context: context)
         },
         error: { message, context in
-            .run(operation: { _ in
-                Logger.error(message, context: context)
-            })
+            Logger.error(message, context: context)
         }
     )
 }
@@ -44,8 +40,8 @@ extension DependencyValues {
 // MARK: Test
 extension LoggerClient {
     static let noop: Self = .init(
-        info: { _, _ in .none },
-        error: { _, _ in .none }
+        info: { _, _ in },
+        error: { _, _ in }
     )
 
     static let unimplemented: Self = .init(

--- a/EhPanda/App/Tools/Clients/UIApplicationClient.swift
+++ b/EhPanda/App/Tools/Clients/UIApplicationClient.swift
@@ -10,60 +10,50 @@ import Combine
 import ComposableArchitecture
 
 struct UIApplicationClient {
-    let openURL: (URL) -> Effect<Never>
-    let hideKeyboard: () -> Effect<Never>
+    let openURL: (URL) -> Void
+    let hideKeyboard: () -> Void
     let alternateIconName: () -> String?
-    let setAlternateIconName: (String?) -> Effect<Result<Bool, Never>>
-    let setUserInterfaceStyle: (UIUserInterfaceStyle) -> Effect<Never>
+    let setAlternateIconName: @MainActor (String?) async -> Bool
+    let setUserInterfaceStyle: @MainActor (UIUserInterfaceStyle) -> Void
 }
 
 extension UIApplicationClient {
     static let live: Self = .init(
         openURL: { url in
-            .fireAndForget {
-                UIApplication.shared.open(url, options: [:])
-            }
+            UIApplication.shared.open(url, options: [:])
         },
         hideKeyboard: {
-            .fireAndForget {
-                UIApplication.shared.endEditing()
-            }
+            UIApplication.shared.endEditing()
         },
         alternateIconName: {
             UIApplication.shared.alternateIconName
         },
         setAlternateIconName: { iconName in
-            Future { promise in
+            await withCheckedContinuation { continuation in
                 UIApplication.shared.setAlternateIconName(iconName) { error in
                     if let error = error {
-                        promise(.success(false))
+                        continuation.resume(returning: false)
                     } else {
-                        promise(.success(true))
+                        continuation.resume(returning: true)
                     }
                 }
             }
-            .eraseToAnyPublisher()
-            .catchToEffect()
         },
         setUserInterfaceStyle: { userInterfaceStyle in
-            .fireAndForget {
-                (DeviceUtil.keyWindow ?? DeviceUtil.anyWindow)?.overrideUserInterfaceStyle = userInterfaceStyle
-            }
+            (DeviceUtil.keyWindow ?? DeviceUtil.anyWindow)?.overrideUserInterfaceStyle = userInterfaceStyle
         }
     )
-    func openSettings() -> Effect<Never> {
+    func openSettings() {
         if let url = URL(string: UIApplication.openSettingsURLString) {
             return openURL(url)
         }
-        return .none
     }
-    func openFileApp() -> Effect<Never> {
+    func openFileApp() {
         if let dirPath = FileUtil.logsDirectoryURL?.path,
            let dirURL = URL(string: "shareddocuments://" + dirPath)
         {
             return openURL(dirURL)
         }
-        return .none
     }
 }
 
@@ -84,11 +74,11 @@ extension DependencyValues {
 // MARK: Test
 extension UIApplicationClient {
     static let noop: Self = .init(
-        openURL: { _ in .none},
-        hideKeyboard: { .none },
+        openURL: { _ in},
+        hideKeyboard: {},
         alternateIconName: { nil },
-        setAlternateIconName: { _ in .none },
-        setUserInterfaceStyle: { _ in .none }
+        setAlternateIconName: { _ in false },
+        setUserInterfaceStyle: { _ in }
     )
 
     static let unimplemented: Self = .init(

--- a/EhPanda/App/Tools/Clients/UserDefaultsClient.swift
+++ b/EhPanda/App/Tools/Clients/UserDefaultsClient.swift
@@ -9,15 +9,13 @@ import Foundation
 import ComposableArchitecture
 
 struct UserDefaultsClient {
-    let setValue: (Any, AppUserDefaults) -> Effect<Never>
+    let setValue: (Any, AppUserDefaults) -> Void
 }
 
 extension UserDefaultsClient {
     static let live: Self = .init(
         setValue: { value, key in
-            .run(operation: { _ in
-                UserDefaults.standard.set(value, forKey: key.rawValue)
-            })
+            UserDefaults.standard.set(value, forKey: key.rawValue)
         }
     )
 
@@ -43,7 +41,7 @@ extension DependencyValues {
 // MARK: Test
 extension UserDefaultsClient {
     static let noop: Self = .init(
-        setValue: { _, _ in .none }
+        setValue: { _, _ in }
     )
 
     static let unimplemented: Self = .init(

--- a/EhPanda/App/Tools/Extensions/Reducer_Extension.swift
+++ b/EhPanda/App/Tools/Extensions/Reducer_Extension.swift
@@ -16,7 +16,9 @@ extension Reducer {
         style: UIImpactFeedbackGenerator.FeedbackStyle = .light
     ) -> some Reducer<State, Action> {
         onBecomeNonNil(unwrapping: `enum`, case: casePath) { _, _ in
-            .run(operation: { _ in hapticsClient.generateFeedback(style) })
+            .run { _ in
+                hapticsClient.generateFeedback(style)
+            }
         }
     }
 

--- a/EhPanda/DataFlow/AppDelegateReducer.swift
+++ b/EhPanda/DataFlow/AppDelegateReducer.swift
@@ -30,17 +30,31 @@ struct AppDelegateReducer: Reducer {
             switch action {
             case .onLaunchFinish:
                 return .merge(
-                    libraryClient.initializeLogger().fireAndForget(),
-                    libraryClient.initializeWebImage().fireAndForget(),
-                    cookieClient.removeYay().fireAndForget(),
-                    cookieClient.syncExCookies().fireAndForget(),
-                    cookieClient.ignoreOffensive().fireAndForget(),
-                    cookieClient.fulfillAnotherHostField().fireAndForget(),
-                    Effect.send(.migration(.prepareDatabase))
+                    .run { _ in
+                        libraryClient.initializeLogger()
+                    },
+                    .run { _ in
+                        libraryClient.initializeWebImage()
+                    },
+                    .run { _ in
+                        cookieClient.removeYay()
+                    },
+                    .run { _ in
+                        cookieClient.syncExCookies()
+                    },
+                    .run { _ in
+                        cookieClient.ignoreOffensive()
+                    },
+                    .run { _ in
+                        cookieClient.fulfillAnotherHostField()
+                    },
+                    .send(.migration(.prepareDatabase))
                 )
 
             case .removeExpiredImageURLs:
-                return databaseClient.removeExpiredImageURLs().fireAndForget()
+                return .run { _ in
+                    await databaseClient.removeExpiredImageURLs()
+                }
 
             case .migration:
                 return .none

--- a/EhPanda/DataFlow/AppLockReducer.swift
+++ b/EhPanda/DataFlow/AppLockReducer.swift
@@ -39,8 +39,8 @@ struct AppLockReducer: Reducer {
                    Date.now.timeIntervalSince(date) >= Double(threshold)
                 {
                     return .merge(
-                        Effect.send(.authorize),
-                        Effect.send(.lockApp(blurRadius))
+                        .send(.authorize),
+                        .send(.lockApp(blurRadius))
                     )
                 } else {
                     return .send(.unlockApp)
@@ -63,11 +63,13 @@ struct AppLockReducer: Reducer {
                 return .none
 
             case .authorize:
-                return authorizationClient.localAuthroize(L10n.Localizable.LocalAuthorization.reason)
-                    .map(Action.authorizeDone)
+                return .run { send in
+                    let success = await authorizationClient.localAuthroize(L10n.Localizable.LocalAuthorization.reason)
+                    await send(.authorizeDone(success))
+                }
 
             case .authorizeDone(let isSucceeded):
-                return isSucceeded ? Effect.send(.unlockApp) : .none
+                return isSucceeded ? .send(.unlockApp) : .none
             }
         }
     }

--- a/EhPanda/View/Detail/Archives/ArchivesReducer.swift
+++ b/EhPanda/View/Detail/Archives/ArchivesReducer.swift
@@ -62,8 +62,9 @@ struct ArchivesReducer: Reducer {
                 return .none
 
             case .syncGalleryFunds(let galleryPoints, let credits):
-                return databaseClient
-                    .updateGalleryFunds(galleryPoints: galleryPoints, credits: credits).fireAndForget()
+                return .run { _ in
+                    await databaseClient.updateGalleryFunds(galleryPoints: galleryPoints, credits: credits)
+                }
 
             case .teardown:
                 return .merge(CancelID.allCases.map(Effect.cancel(id:)))

--- a/EhPanda/View/Detail/Comments/CommentsReducer.swift
+++ b/EhPanda/View/Detail/Comments/CommentsReducer.swift
@@ -76,14 +76,14 @@ struct CommentsReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? Effect.send(.clearSubStates) : .none
+                return state.route == nil ? .send(.clearSubStates) : .none
 
             case .binding:
                 return .none
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? Effect.send(.clearSubStates) : .none
+                return route == nil ? .send(.clearSubStates) : .none
 
             case .clearSubStates:
                 state.detailState = .init()
@@ -113,23 +113,25 @@ struct CommentsReducer: Reducer {
 
             case .performScrollOpacityEffect:
                 return .merge(
-                    .publisher {
-                        Effect.send(.setScrollRowOpacity(0.25))
-                            .delay(for: .milliseconds(750), scheduler: DispatchQueue.main)
+                    .run { send in
+                        try await Task.sleep(nanoseconds: UInt64(750) * NSEC_PER_MSEC)
+                        await send(.setScrollRowOpacity(0.25))
                     },
-                    .publisher {
-                        Effect.send(.setScrollRowOpacity(1))
-                            .delay(for: .milliseconds(1250), scheduler: DispatchQueue.main)
+                    .run { send in
+                        try await Task.sleep(nanoseconds: UInt64(1250) * NSEC_PER_MSEC)
+                        await send(.setScrollRowOpacity(1))
                     },
-                    .publisher {
-                        Effect.send(.clearScrollCommentID)
-                            .delay(for: .milliseconds(2000), scheduler: DispatchQueue.main)
+                    .run { send in
+                        try await Task.sleep(nanoseconds: UInt64(2000) * NSEC_PER_MSEC)
+                        await send(.clearScrollCommentID)
                     }
                 )
 
             case .handleCommentLink(let url):
                 guard urlClient.checkIfHandleable(url) else {
-                    return uiApplicationClient.openURL(url).fireAndForget()
+                    return .run { _ in
+                        uiApplicationClient.openURL(url)
+                    }
                 }
                 let (isGalleryImageURL, _, _) = urlClient.analyzeURL(url)
                 let gid = urlClient.parseGalleryID(url)
@@ -145,17 +147,17 @@ struct CommentsReducer: Reducer {
                 if let pageIndex = pageIndex {
                     effects.append(.send(.updateReadingProgress(gid, pageIndex)))
                     effects.append(
-                        .publisher {
-                            Effect.send(.detail(.setNavigation(.reading)))
-                                .delay(for: .milliseconds(750), scheduler: DispatchQueue.main)
+                        .run { send in
+                            try await Task.sleep(nanoseconds: UInt64(750) * NSEC_PER_MSEC)
+                            await send(.detail(.setNavigation(.reading)))
                         }
                     )
                 } else if let commentID = commentID {
                     state.detailState.commentsState?.scrollCommentID = commentID
                     effects.append(
-                        .publisher {
-                            Effect.send(.detail(.setNavigation(.comments(url))))
-                                .delay(for: .milliseconds(750), scheduler: DispatchQueue.main)
+                        .run { send in
+                            try await Task.sleep(nanoseconds: UInt64(750) * NSEC_PER_MSEC)
+                            await send(.detail(.setNavigation(.comments(url))))
                         }
                     )
                 }
@@ -163,21 +165,22 @@ struct CommentsReducer: Reducer {
                 return .merge(effects)
 
             case .onPostCommentAppear:
-                return .publisher {
-                    Effect.send(.setPostCommentFocused(true))
-                        .delay(for: .milliseconds(750), scheduler: DispatchQueue.main)
+                return .run { send in
+                    try await Task.sleep(nanoseconds: UInt64(750) * NSEC_PER_MSEC)
+                    await send(.setPostCommentFocused(true))
                 }
 
             case .onAppear:
                 if state.detailState == nil {
                     state.detailState = .init()
                 }
-                return state.scrollCommentID != nil ? Effect.send(.performScrollOpacityEffect) : .none
+                return state.scrollCommentID != nil ? .send(.performScrollOpacityEffect) : .none
 
             case .updateReadingProgress(let gid, let progress):
                 guard !gid.isEmpty else { return .none }
-                return databaseClient
-                    .updateReadingProgress(gid: gid, progress: progress).fireAndForget()
+                return .run { _ in
+                    await databaseClient.updateReadingProgress(gid: gid, progress: progress)
+                }
 
             case .teardown:
                 return .merge(CancelID.allCases.map(Effect.cancel(id:)))
@@ -217,13 +220,15 @@ struct CommentsReducer: Reducer {
                 switch result {
                 case .success(let gallery):
                     return .merge(
-                        databaseClient.cacheGalleries([gallery]).fireAndForget(),
-                        Effect.send(.handleGalleryLink(url))
+                        .run { _ in
+                            await databaseClient.cacheGalleries([gallery])
+                        },
+                        .send(.handleGalleryLink(url))
                     )
                 case .failure:
-                    return .publisher {
-                        Effect.send(.setHUDConfig(.error))
-                            .delay(for: .milliseconds(500), scheduler: DispatchQueue.main)
+                    return .run { send in
+                        try await Task.sleep(nanoseconds: UInt64(500) * NSEC_PER_MSEC)
+                        await send(.setHUDConfig(.error))
                     }
                 }
 

--- a/EhPanda/View/Detail/DetailReducer.swift
+++ b/EhPanda/View/Detail/DetailReducer.swift
@@ -122,14 +122,14 @@ struct DetailReducer: Reducer {
             Reduce { state, action in
                 switch action {
                 case .binding(\.$route):
-                    return state.route == nil ? Effect.send(.clearSubStates) : .none
+                    return state.route == nil ? .send(.clearSubStates) : .none
 
                 case .binding:
                     return .none
 
                 case .setNavigation(let route):
                     state.route = route
-                    return route == nil ? Effect.send(.clearSubStates) : .none
+                    return route == nil ? .send(.clearSubStates) : .none
 
                 case .clearSubStates:
                     state.readingState = .init()
@@ -142,18 +142,18 @@ struct DetailReducer: Reducer {
                     state.galleryInfosState = .init()
                     state.detailSearchState = .init()
                     return .merge(
-                        Effect.send(.reading(.teardown)),
-                        Effect.send(.archives(.teardown)),
-                        Effect.send(.torrents(.teardown)),
-                        Effect.send(.previews(.teardown)),
-                        Effect.send(.comments(.teardown)),
-                        Effect.send(.detailSearch(.teardown))
+                        .send(.reading(.teardown)),
+                        .send(.archives(.teardown)),
+                        .send(.torrents(.teardown)),
+                        .send(.previews(.teardown)),
+                        .send(.comments(.teardown)),
+                        .send(.detailSearch(.teardown))
                     )
 
                 case .onPostCommentAppear:
-                    return .publisher {
-                        Effect.send(.setPostCommentFocused(true))
-                            .delay(for: .milliseconds(750), scheduler: DispatchQueue.main)
+                    return .run { send in
+                        try await Task.sleep(nanoseconds: UInt64(750) * NSEC_PER_MSEC)
+                        await send(.setPostCommentFocused(true))
                     }
 
                 case .onAppear(let gid, let showsNewDawnGreeting):
@@ -168,11 +168,15 @@ struct DetailReducer: Reducer {
 
                 case .toggleShowFullTitle:
                     state.showsFullTitle.toggle()
-                    return .run(operation: { _ in hapticsClient.generateFeedback(.soft) })
+                    return .run { _ in
+                        hapticsClient.generateFeedback(.soft)
+                    }
 
                 case .toggleShowUserRating:
                     state.showsUserRating.toggle()
-                    return .run(operation: { _ in hapticsClient.generateFeedback(.soft) })
+                    return .run { _ in
+                        hapticsClient.generateFeedback(.soft)
+                    }
 
                 case .setCommentContent(let content):
                     state.commentContent = content
@@ -189,10 +193,13 @@ struct DetailReducer: Reducer {
                 case .confirmRating(let value):
                     state.updateRating(value: value)
                     return .merge(
-                        Effect.send(.rateGallery),
-                        .run(operation: { _ in hapticsClient.generateFeedback(.soft) }),
-                        .publisher {
-                            Effect.send(.confirmRatingDone).delay(for: 1, scheduler: DispatchQueue.main)
+                        .send(.rateGallery),
+                        .run { _ in
+                            hapticsClient.generateFeedback(.soft)
+                        },
+                        .run { send in
+                            try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+                            await send(.confirmRatingDone)
                         }
                     )
 
@@ -201,34 +208,46 @@ struct DetailReducer: Reducer {
                     return .none
 
                 case .syncGalleryTags:
-                    return databaseClient
-                        .updateGalleryTags(gid: state.gallery.id, tags: state.galleryTags).fireAndForget()
+                    return .run { [state] _ in
+                        await databaseClient.updateGalleryTags(gid: state.gallery.id, tags: state.galleryTags)
+                    }
 
                 case .syncGalleryDetail:
                     guard let detail = state.galleryDetail else { return .none }
-                    return databaseClient.cacheGalleryDetail(detail).fireAndForget()
+                    return .run { _ in
+                        await databaseClient.cacheGalleryDetail(detail)
+                    }
 
                 case .syncGalleryPreviewURLs:
-                    return databaseClient
-                        .updatePreviewURLs(gid: state.gallery.id, previewURLs: state.galleryPreviewURLs).fireAndForget()
+                    return .run { [state] _ in
+                        await databaseClient
+                            .updatePreviewURLs(gid: state.gallery.id, previewURLs: state.galleryPreviewURLs)
+                    }
 
                 case .syncGalleryComments:
-                    return databaseClient
-                        .updateComments(gid: state.gallery.id, comments: state.galleryComments).fireAndForget()
+                    return .run { [state] _ in
+                        await databaseClient.updateComments(gid: state.gallery.id, comments: state.galleryComments)
+                    }
 
                 case .syncGreeting(let greeting):
-                    return databaseClient.updateGreeting(greeting).fireAndForget()
+                    return .run { _ in
+                        await databaseClient.updateGreeting(greeting)
+                    }
 
                 case .syncPreviewConfig(let config):
-                    return databaseClient
-                        .updatePreviewConfig(gid: state.gallery.id, config: config).fireAndForget()
+                    return .run { [state] _ in
+                        await databaseClient.updatePreviewConfig(gid: state.gallery.id, config: config)
+                    }
 
                 case .saveGalleryHistory:
-                    return databaseClient.updateLastOpenDate(gid: state.gallery.id).fireAndForget()
+                    return .run { [state] _ in
+                        await databaseClient.updateLastOpenDate(gid: state.gallery.id)
+                    }
 
                 case .updateReadingProgress(let progress):
-                    return databaseClient
-                        .updateReadingProgress(gid: state.gallery.id, progress: progress).fireAndForget()
+                    return .run { [state] _ in
+                        await databaseClient.updateReadingProgress(gid: state.gallery.id, progress: progress)
+                    }
 
                 case .teardown:
                     return .merge(CancelID.allCases.map(Effect.cancel(id:)))
@@ -240,9 +259,12 @@ struct DetailReducer: Reducer {
                         state.galleryDetail = detail
                     }
                     return .merge(
-                        Effect.send(.saveGalleryHistory),
-                        databaseClient.fetchGalleryState(gid: state.gallery.id)
-                            .map(Action.fetchDatabaseInfosDone).cancellable(id: CancelID.fetchDatabaseInfos)
+                        .send(.saveGalleryHistory),
+                        .run { [state] send in
+                            guard let dbState = await databaseClient.fetchGalleryState(gid: state.gallery.id) else { return }
+                            await send(.fetchDatabaseInfosDone(dbState))
+                        }
+                        .cancellable(id: CancelID.fetchDatabaseInfos)
                     )
 
                 case .fetchDatabaseInfosDone(let galleryState):
@@ -264,10 +286,10 @@ struct DetailReducer: Reducer {
                     switch result {
                     case .success(let (galleryDetail, galleryState, apiKey, greeting)):
                         var effects: [Effect<Action>] = [
-                            Effect.send(.syncGalleryTags),
-                            Effect.send(.syncGalleryDetail),
-                            Effect.send(.syncGalleryPreviewURLs),
-                            Effect.send(.syncGalleryComments)
+                            .send(.syncGalleryTags),
+                            .send(.syncGalleryDetail),
+                            .send(.syncGalleryPreviewURLs),
+                            .send(.syncGalleryComments)
                         ]
                         state.apiKey = apiKey
                         state.galleryDetail = galleryDetail
@@ -323,11 +345,15 @@ struct DetailReducer: Reducer {
                 case .anyGalleryOpsDone(let result):
                     if case .success = result {
                         return .merge(
-                            Effect.send(.fetchGalleryDetail),
-                            .run(operation: { _ in hapticsClient.generateNotificationFeedback(.success) })
+                            .send(.fetchGalleryDetail),
+                            .run { _ in
+                                hapticsClient.generateNotificationFeedback(.success)
+                            }
                         )
                     }
-                    return .run(operation: { _ in hapticsClient.generateNotificationFeedback(.error) })
+                    return .run { _ in
+                        hapticsClient.generateNotificationFeedback(.error)
+                    }
 
                 case .reading(.onPerformDismiss):
                     return .send(.setNavigation(nil))

--- a/EhPanda/View/Detail/GalleryInfos/GalleryInfosReducer.swift
+++ b/EhPanda/View/Detail/GalleryInfos/GalleryInfosReducer.swift
@@ -37,8 +37,12 @@ struct GalleryInfosReducer: Reducer {
             case .copyText(let text):
                 state.route = .hud
                 return .merge(
-                    clipboardClient.saveText(text).fireAndForget(),
-                    .run(operation: { _ in hapticsClient.generateNotificationFeedback(.success) })
+                    .run { _ in
+                        clipboardClient.saveText(text)
+                    },
+                    .run { _ in
+                        hapticsClient.generateNotificationFeedback(.success)
+                    }
                 )
             }
         }

--- a/EhPanda/View/Detail/Torrents/TorrentsReducer.swift
+++ b/EhPanda/View/Detail/Torrents/TorrentsReducer.swift
@@ -59,8 +59,12 @@ struct TorrentsReducer: Reducer {
             case .copyText(let magnetURL):
                 state.route = .hud
                 return .merge(
-                    clipboardClient.saveText(magnetURL).fireAndForget(),
-                    .run(operation: { _ in hapticsClient.generateNotificationFeedback(.success) })
+                    .run { _ in
+                        clipboardClient.saveText(magnetURL)
+                    },
+                    .run { _ in
+                        hapticsClient.generateNotificationFeedback(.success)
+                    }
                 )
 
             case .presentTorrentActivity(let hash, let data):

--- a/EhPanda/View/Home/Frontpage/FrontpageReducer.swift
+++ b/EhPanda/View/Home/Frontpage/FrontpageReducer.swift
@@ -70,14 +70,14 @@ struct FrontpageReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? Effect.send(.clearSubStates) : .none
+                return state.route == nil ? .send(.clearSubStates) : .none
 
             case .binding:
                 return .none
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? Effect.send(.clearSubStates) : .none
+                return route == nil ? .send(.clearSubStates) : .none
 
             case .clearSubStates:
                 state.detailState = .init()
@@ -107,7 +107,9 @@ struct FrontpageReducer: Reducer {
                     }
                     state.pageNumber = pageNumber
                     state.galleries = galleries
-                    return databaseClient.cacheGalleries(galleries).fireAndForget()
+                    return .run { _ in
+                        await databaseClient.cacheGalleries(galleries)
+                    }
                 case .failure(let error):
                     state.loadingState = .failed(error)
                 }
@@ -133,7 +135,9 @@ struct FrontpageReducer: Reducer {
                     state.insertGalleries(galleries)
 
                     var effects: [Effect<Action>] = [
-                        databaseClient.cacheGalleries(galleries).fireAndForget()
+                        .run { _ in
+                            await databaseClient.cacheGalleries(galleries)
+                        }
                     ]
                     if galleries.isEmpty, pageNumber.hasNextPage() {
                         effects.append(.send(.fetchMoreGalleries))

--- a/EhPanda/View/Home/Popular/PopularReducer.swift
+++ b/EhPanda/View/Home/Popular/PopularReducer.swift
@@ -58,14 +58,14 @@ struct PopularReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? Effect.send(.clearSubStates) : .none
+                return state.route == nil ? .send(.clearSubStates) : .none
 
             case .binding:
                 return .none
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? Effect.send(.clearSubStates) : .none
+                return route == nil ? .send(.clearSubStates) : .none
 
             case .clearSubStates:
                 state.detailState = .init()
@@ -91,7 +91,9 @@ struct PopularReducer: Reducer {
                         return .none
                     }
                     state.galleries = galleries
-                    return databaseClient.cacheGalleries(galleries).fireAndForget()
+                    return .run { _ in
+                        await databaseClient.cacheGalleries(galleries)
+                    }
                 case .failure(let error):
                     state.loadingState = .failed(error)
                 }

--- a/EhPanda/View/Search/SearchReducer.swift
+++ b/EhPanda/View/Search/SearchReducer.swift
@@ -70,7 +70,7 @@ struct SearchReducer: Reducer {
         Reduce { state, action in
             switch action {
             case .binding(\.$route):
-                return state.route == nil ? Effect.send(.clearSubStates) : .none
+                return state.route == nil ? .send(.clearSubStates) : .none
 
             case .binding(\.$keyword):
                 if !state.keyword.isEmpty {
@@ -83,15 +83,15 @@ struct SearchReducer: Reducer {
 
             case .setNavigation(let route):
                 state.route = route
-                return route == nil ? Effect.send(.clearSubStates) : .none
+                return route == nil ? .send(.clearSubStates) : .none
 
             case .clearSubStates:
                 state.detailState = .init()
                 state.filtersState = .init()
                 state.quickSearchState = .init()
                 return .merge(
-                    Effect.send(.detail(.teardown)),
-                    Effect.send(.quickSearch(.teardown))
+                    .send(.detail(.teardown)),
+                    .send(.quickSearch(.teardown))
                 )
 
             case .teardown:
@@ -121,7 +121,9 @@ struct SearchReducer: Reducer {
                     }
                     state.pageNumber = pageNumber
                     state.galleries = galleries
-                    return databaseClient.cacheGalleries(galleries).fireAndForget()
+                    return .run { _ in
+                        await databaseClient.cacheGalleries(galleries)
+                    }
                 case .failure(let error):
                     state.loadingState = .failed(error)
                 }
@@ -147,7 +149,9 @@ struct SearchReducer: Reducer {
                     state.insertGalleries(galleries)
 
                     var effects: [Effect<Action>] = [
-                        databaseClient.cacheGalleries(galleries).fireAndForget()
+                        .run { _ in
+                            await databaseClient.cacheGalleries(galleries)
+                        }
                     ]
                     if galleries.isEmpty, pageNumber.hasNextPage() {
                         effects.append(.send(.fetchMoreGalleries))

--- a/EhPanda/View/Setting/AccountSetting/AccountSettingReducer.swift
+++ b/EhPanda/View/Setting/AccountSetting/AccountSettingReducer.swift
@@ -52,10 +52,14 @@ struct AccountSettingReducer: Reducer {
                 return state.route == nil ? .send(.clearSubStates) : .none
 
             case .binding(\.$ehCookiesState):
-                return cookieClient.setCookies(state: state.ehCookiesState).fireAndForget()
+                return .run { [state] _ in
+                    cookieClient.setCookies(state: state.ehCookiesState)
+                }
 
             case .binding(\.$exCookiesState):
-                return cookieClient.setCookies(state: state.exCookiesState).fireAndForget()
+                return .run { [state] _ in
+                    cookieClient.setCookies(state: state.exCookiesState)
+                }
 
             case .binding:
                 return .none
@@ -84,8 +88,12 @@ struct AccountSettingReducer: Reducer {
                 let cookiesDescription = cookieClient.getCookiesDescription(host: host)
                 return .merge(
                     .send(.setNavigation(.hud)),
-                    clipboardClient.saveText(cookiesDescription).fireAndForget(),
-                    .run(operation: { _ in hapticsClient.generateNotificationFeedback(.success) })
+                    .run { _ in
+                        clipboardClient.saveText(cookiesDescription)
+                    },
+                    .run { _ in
+                        hapticsClient.generateNotificationFeedback(.success)
+                    }
                 )
 
             case .login(.loginDone):

--- a/EhPanda/View/Setting/EhSetting/EhSettingReducer.swift
+++ b/EhPanda/View/Setting/EhSetting/EhSettingReducer.swift
@@ -67,13 +67,16 @@ struct EhSettingReducer: Reducer {
                 return .none
 
             case .setKeyboardHidden:
-                return uiApplicationClient.hideKeyboard().fireAndForget()
+                return .run { _ in
+                    uiApplicationClient.hideKeyboard()
+                }
 
             case .setDefaultProfile(let profileSet):
-                return cookieClient.setOrEditCookie(
-                    for: Defaults.URL.host, key: Defaults.Cookie.selectedProfile, value: String(profileSet)
-                )
-                .fireAndForget()
+                return .run { _ in
+                    cookieClient.setOrEditCookie(
+                        for: Defaults.URL.host, key: Defaults.Cookie.selectedProfile, value: String(profileSet)
+                    )
+                }
 
             case .teardown:
                 return .merge(CancelID.allCases.map(Effect.cancel(id:)))

--- a/EhPanda/View/Support/FiltersReducer.swift
+++ b/EhPanda/View/Support/FiltersReducer.swift
@@ -85,7 +85,9 @@ struct FiltersReducer: Reducer {
                 case .watched:
                     filter = state.watchedFilter
                 }
-                return databaseClient.updateFilter(filter, range: range).fireAndForget()
+                return .run { _ in
+                    await databaseClient.updateFilter(filter, range: range)
+                }
 
             case .resetFilters:
                 switch state.filterRange {
@@ -101,7 +103,10 @@ struct FiltersReducer: Reducer {
                 }
 
             case .fetchFilters:
-                return databaseClient.fetchAppEnv().map(Action.fetchFiltersDone)
+                return .run { send in
+                    let appEnv = await databaseClient.fetchAppEnv()
+                    await send(.fetchFiltersDone(appEnv))
+                }
 
             case .fetchFiltersDone(let appEnv):
                 state.searchFilter = appEnv.searchFilter

--- a/EhPanda/View/TabBar/TabBarView.swift
+++ b/EhPanda/View/TabBar/TabBarView.swift
@@ -34,7 +34,7 @@ struct TabBarView: View {
                             HomeView(
                                 store: store.scope(state: \.homeState, action: AppReducer.Action.home),
                                 user: viewStore.settingState.user,
-                                setting: viewStore.binding(\.settingState.$setting),
+                                setting: viewStore.$settingState.setting,
                                 blurRadius: viewStore.appLockState.blurRadius,
                                 tagTranslator: viewStore.settingState.tagTranslator
                             )
@@ -42,7 +42,7 @@ struct TabBarView: View {
                             FavoritesView(
                                 store: store.scope(state: \.favoritesState, action: AppReducer.Action.favorites),
                                 user: viewStore.settingState.user,
-                                setting: viewStore.binding(\.settingState.$setting),
+                                setting: viewStore.$settingState.setting,
                                 blurRadius: viewStore.appLockState.blurRadius,
                                 tagTranslator: viewStore.settingState.tagTranslator
                             )
@@ -50,7 +50,7 @@ struct TabBarView: View {
                             SearchRootView(
                                 store: store.scope(state: \.searchRootState, action: AppReducer.Action.searchRoot),
                                 user: viewStore.settingState.user,
-                                setting: viewStore.binding(\.settingState.$setting),
+                                setting: viewStore.$settingState.setting,
                                 blurRadius: viewStore.appLockState.blurRadius,
                                 tagTranslator: viewStore.settingState.tagTranslator
                             )
@@ -73,11 +73,11 @@ struct TabBarView: View {
             }
             .font(.system(size: 80)).opacity(viewStore.appLockState.isAppLocked ? 1 : 0)
         }
-        .sheet(unwrapping: viewStore.binding(\.appRouteState.$route), case: /AppRouteReducer.Route.newDawn) { route in
+        .sheet(unwrapping: viewStore.$appRouteState.route, case: /AppRouteReducer.Route.newDawn) { route in
             NewDawnView(greeting: route.wrappedValue)
                 .autoBlur(radius: viewStore.appLockState.blurRadius)
         }
-        .sheet(unwrapping: viewStore.binding(\.appRouteState.$route), case: /AppRouteReducer.Route.setting) { _ in
+        .sheet(unwrapping: viewStore.$appRouteState.route, case: /AppRouteReducer.Route.setting) { _ in
             SettingView(
                 store: store.scope(state: \.settingState, action: AppReducer.Action.setting),
                 blurRadius: viewStore.appLockState.blurRadius
@@ -85,7 +85,7 @@ struct TabBarView: View {
             .accentColor(viewStore.settingState.setting.accentColor)
             .autoBlur(radius: viewStore.appLockState.blurRadius)
         }
-        .sheet(unwrapping: viewStore.binding(\.appRouteState.$route), case: /AppRouteReducer.Route.detail) { route in
+        .sheet(unwrapping: viewStore.$appRouteState.route, case: /AppRouteReducer.Route.detail) { route in
             NavigationView {
                 DetailView(
                     store: store.scope(
@@ -93,7 +93,7 @@ struct TabBarView: View {
                         action: { AppReducer.Action.appRoute(.detail($0)) }
                     ),
                     gid: route.wrappedValue, user: viewStore.settingState.user,
-                    setting: viewStore.binding(\.settingState.$setting),
+                    setting: viewStore.$settingState.setting,
                     blurRadius: viewStore.appLockState.blurRadius,
                     tagTranslator: viewStore.settingState.tagTranslator
                 )
@@ -105,7 +105,7 @@ struct TabBarView: View {
         }
         .progressHUD(
             config: viewStore.appRouteState.hudConfig,
-            unwrapping: viewStore.binding(\.appRouteState.$route),
+            unwrapping: viewStore.$appRouteState.route,
             case: /AppRouteReducer.Route.hud
         )
         .onChange(of: scenePhase) { viewStore.send(.onScenePhaseChange($0)) }


### PR DESCRIPTION
This pr fix all but two warnings before migrating to TCA 1.0.

Most of the warnings are 
- `fireAndForget is deprecated`
- `Conformance of 'EffectPublisher<Action, Failure>' to 'Publisher' is deprecated`

The technique used here is turn methods in client to simple method or async method if it uses promise

For example:
- Turn `(Input) -> Effect<Never>` to `(Input) -> Void` or `(Input) async -> Void`
- Turn `(Input) -> Effect<Output>` to `(Input) -> Output` or `(Input) async -> Output`

Then make corresponding changes in reducers

---

The warnings left are

```swift
EhProfileRequest(action: .create, name: "EhPanda").effect.fireAndForget()

// and

extension Request {
    var effect: Effect<Result<Response, AppError>> {
        publisher.receive(on: DispatchQueue.main).catchToEffect()
    }
```