### PR TITLE
Jimmy/fix publisher deprecated

### DIFF
--- a/EhPanda.xcodeproj/project.pbxproj
+++ b/EhPanda.xcodeproj/project.pbxproj
@@ -2408,8 +2408,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-composable-architecture.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.0;
+				kind = exactVersion;
+				version = 1.0.0;
 			};
 		};
 		ABAC82FC26BC4866009F5026 /* XCRemoteSwiftPackageReference "SwiftyOpenCC" */ = {
@@ -2424,8 +2424,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swiftui-navigation.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.0;
+				kind = exactVersion;
+				version = 1.0.0;
 			};
 		};
 		ABC4A0772751B40E00968A4F /* XCRemoteSwiftPackageReference "Kingfisher" */ = {

--- a/EhPanda.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EhPanda.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "ec62f32d21584214a4b27c8cee2b2ad70ab2c38a",
-        "version" : "0.11.0"
+        "revision" : "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
+        "version" : "1.0.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tid-kijyun/Kanna.git",
       "state" : {
-        "revision" : "f9e4922223dd0d3dfbf02ca70812cf5531fc0593",
-        "version" : "5.2.7"
+        "revision" : "41c3d28ea0eac07e4551b28def9de1ede702e739",
+        "version" : "5.3.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "3ec0ab0bca4feb56e8b33e289c9496e89059dd08",
-        "version" : "7.10.2"
+        "revision" : "5b92f029fab2cce44386d28588098b5be0824ef5",
+        "version" : "7.11.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "fc45e7b2cfece9dd80b5a45e6469ffe67fe67984",
-        "version" : "0.14.1"
+        "revision" : "e593aba2c6222daad7c4f2732a431eed2c09bb07",
+        "version" : "1.3.0"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "0fbaebfc013715dab44d715a4d350ba37f297e4d",
-        "version" : "0.4.0"
+        "revision" : "a8421d68068d8f45fbceb418fbf22c5dad4afd33",
+        "version" : "1.0.2"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "d029d9d39c87bed85b1c50adee7c41795261a192",
-        "version" : "1.0.6"
+        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
+        "version" : "1.1.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
-        "revision" : "9f4202ab5b8422aa90f0ed983bf7652c3af7abf0",
-        "version" : "0.59.0"
+        "revision" : "195284b94b799b326729640453f547f08892293a",
+        "version" : "1.0.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "479750bd98fac2e813fffcf2af0728b5b0085795",
-        "version" : "0.1.1"
+        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
+        "version" : "1.1.0"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "4a87bb75be70c983a9548597e8783236feb3401e",
-        "version" : "0.11.1"
+        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
+        "version" : "1.3.0"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "16fd42ae04c6e7f74a6a86395d04722c641cccee",
-        "version" : "0.6.0"
+        "revision" : "d3a5af3038a09add4d7682f66555d6212058a3c0",
+        "version" : "1.2.2"
       }
     },
     {
@@ -140,8 +140,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",
       "state" : {
-        "revision" : "d01446a78fb768adc9a78cbb6df07767c8ccfc29",
-        "version" : "0.8.0"
+        "revision" : "d1e45f3e1eee2c9193f5369fa9d70a6ddad635e8",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax",
+      "state" : {
+        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
+        "version" : "510.0.1"
       }
     },
     {
@@ -158,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation.git",
       "state" : {
-        "revision" : "2aa885e719087ee19df251c08a5980ad3e787f12",
-        "version" : "0.8.0"
+        "revision" : "f5bcdac5b6bb3f826916b14705f37a3937c2fd34",
+        "version" : "1.0.0"
       }
     },
     {
@@ -221,8 +230,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "50843cbb8551db836adec2290bb4bc6bac5c1865",
-        "version" : "0.9.0"
+        "revision" : "b13b1d1a8e787a5ffc71ac19dcaf52183ab27ba2",
+        "version" : "1.1.1"
       }
     }
   ],

--- a/EhPanda/App/Tools/Extensions/Reducer_Extension.swift
+++ b/EhPanda/App/Tools/Extensions/Reducer_Extension.swift
@@ -11,7 +11,7 @@ import ComposableArchitecture
 extension Reducer {
     func haptics<Enum, Case>(
         unwrapping enum: @escaping (State) -> Enum?,
-        case casePath: CasePath<Enum, Case>,
+        case casePath: AnyCasePath<Enum, Case>,
         hapticsClient: HapticsClient,
         style: UIImpactFeedbackGenerator.FeedbackStyle = .light
     ) -> some Reducer<State, Action> {
@@ -24,7 +24,7 @@ extension Reducer {
 
     private func onBecomeNonNil<Enum, Case>(
         unwrapping enum: @escaping (State) -> Enum?,
-        case casePath: CasePath<Enum, Case>,
+        case casePath: AnyCasePath<Enum, Case>,
         perform additionalEffects: @escaping (inout State, Action) -> Effect<Action>
     ) -> some Reducer<State, Action> {
         Reduce { state, action in

--- a/EhPanda/App/Tools/Extensions/SwiftUINavigation_Extension.swift
+++ b/EhPanda/App/Tools/Extensions/SwiftUINavigation_Extension.swift
@@ -23,7 +23,7 @@ extension NavigationLink {
     }
     init<Enum, Case, WrappedDestination>(
         unwrapping enum: Binding<Enum?>,
-        case casePath: CasePath<Enum, Case>,
+        case casePath: AnyCasePath<Enum, Case>,
         @ViewBuilder destination: @escaping (Binding<Case>) -> WrappedDestination
     ) where Destination == WrappedDestination?, Label == Text {
         self.init(
@@ -38,7 +38,7 @@ extension View {
     @ViewBuilder
     func sheet<Enum, Case, Content>(
         unwrapping enum: Binding<Enum?>,
-        case casePath: CasePath<Enum, Case>,
+        case casePath: AnyCasePath<Enum, Case>,
         onDismiss: (() -> Void)? = nil,
         isEnabled: Bool,
         @ViewBuilder content: @escaping (Binding<Case>) -> Content
@@ -53,7 +53,7 @@ extension View {
     func confirmationDialog<Enum, Case, A: View>(
         message: String,
         unwrapping enum: Binding<Enum?>,
-        case casePath: CasePath<Enum, Case>,
+        case casePath: AnyCasePath<Enum, Case>,
         @ViewBuilder actions: @escaping (Case) -> A
     ) -> some View {
         self.confirmationDialog(
@@ -67,7 +67,7 @@ extension View {
     func confirmationDialog<Enum, Case: Equatable, A: View>(
         message: String,
         unwrapping enum: Binding<Enum?>,
-        case casePath: CasePath<Enum, Case>,
+        case casePath: AnyCasePath<Enum, Case>,
         matching case: Case,
         @ViewBuilder actions: @escaping (Case) -> A
     ) -> some View {
@@ -87,7 +87,7 @@ extension View {
     func progressHUD<Enum: Equatable, Case>(
         config: TTProgressHUDConfig,
         unwrapping enum: Binding<Enum?>,
-        case casePath: CasePath<Enum, Case>
+        case casePath: AnyCasePath<Enum, Case>
     ) -> some View {
         ZStack {
             self

--- a/EhPanda/DataFlow/AppReducer.swift
+++ b/EhPanda/DataFlow/AppReducer.swift
@@ -43,15 +43,19 @@ struct AppReducer: Reducer {
     var body: some Reducer<State, Action> {
         LoggingReducer {
             BindingReducer()
+                .onChange(of: \.appRouteState.route) { _, newValue in
+                    Reduce { _, _ in
+                        return newValue == nil ? .send(.appRoute(.clearSubStates)) : .none
+                    }
+                }
+                .onChange(of: \.settingState.setting) { _, _ in
+                    Reduce { _, _ in
+                        return .send(.setting(.syncSetting))
+                    }
+                }
 
             Reduce { state, action in
                 switch action {
-                case .binding(\.appRouteState.$route):
-                    return state.appRouteState.route == nil ? .send(.appRoute(.clearSubStates)) : .none
-
-                case .binding(\.settingState.$setting):
-                    return .send(.setting(.syncSetting))
-
                 case .binding:
                     return .none
 

--- a/EhPanda/DataFlow/AppRouteReducer.swift
+++ b/EhPanda/DataFlow/AppRouteReducer.swift
@@ -146,8 +146,10 @@ struct AppRouteReducer: Reducer {
 
             case .fetchGallery(let url, let isGalleryImageURL):
                 state.route = .hud
-                return GalleryReverseRequest(url: url, isGalleryImageURL: isGalleryImageURL)
-                    .effect.map({ Action.fetchGalleryDone(url, $0) })
+                return .run { send in
+                    let response = await GalleryReverseRequest(url: url, isGalleryImageURL: isGalleryImageURL).response()
+                    await send(Action.fetchGalleryDone(url, response))
+                }
 
             case .fetchGalleryDone(let url, let result):
                 state.route = nil

--- a/EhPanda/Network/Request.swift
+++ b/EhPanda/Network/Request.swift
@@ -16,11 +16,6 @@ protocol Request {
     var publisher: AnyPublisher<Response, AppError> { get }
 }
 extension Request {
-    @available(*, deprecated, renamed: "response", message: "Use `response`")
-    var effect: Effect<Result<Response, AppError>> {
-        publisher.receive(on: DispatchQueue.main).catchToEffect()
-    }
-
     func response() async -> Result<Response, AppError> {
         await publisher.receive(on: DispatchQueue.main).async()
     }

--- a/EhPanda/View/Detail/DetailReducer.swift
+++ b/EhPanda/View/Detail/DetailReducer.swift
@@ -323,7 +323,7 @@ struct DetailReducer: Reducer {
                             apiuid: apiuid,
                             apikey: state.apiKey,
                             gid: gid,
-                            token: state.gallery.token, 
+                            token: state.gallery.token,
                             rating: state.userRating
                         ).response()
                         await send(Action.anyGalleryOpsDone(response))

--- a/EhPanda/View/Detail/DetailSearch/DetailSearchReducer.swift
+++ b/EhPanda/View/Detail/DetailSearch/DetailSearchReducer.swift
@@ -106,8 +106,11 @@ struct DetailSearchReducer: Reducer {
                 state.loadingState = .loading
                 state.pageNumber.resetPages()
                 let filter = databaseClient.fetchFilterSynchronously(range: .search)
-                return SearchGalleriesRequest(keyword: state.lastKeyword, filter: filter).effect
-                    .map(Action.fetchGalleriesDone).cancellable(id: CancelID.fetchGalleries)
+                return .run { [lastKeyword = state.lastKeyword] send in
+                    let response = await SearchGalleriesRequest(keyword: lastKeyword, filter: filter).response()
+                    await send(Action.fetchGalleriesDone(response))
+                }
+                .cancellable(id: CancelID.fetchGalleries)
 
             case .fetchGalleriesDone(let result):
                 state.loadingState = .idle
@@ -136,9 +139,11 @@ struct DetailSearchReducer: Reducer {
                 else { return .none }
                 state.footerLoadingState = .loading
                 let filter = databaseClient.fetchFilterSynchronously(range: .search)
-                return MoreSearchGalleriesRequest(keyword: state.lastKeyword, filter: filter, lastID: lastID).effect
-                    .map(Action.fetchMoreGalleriesDone)
-                    .cancellable(id: CancelID.fetchMoreGalleries)
+                return .run { [lastKeyword = state.lastKeyword] send in
+                    let response = await MoreSearchGalleriesRequest(keyword: lastKeyword, filter: filter, lastID: lastID).response()
+                    await send(Action.fetchMoreGalleriesDone(response))
+                }
+                .cancellable(id: CancelID.fetchMoreGalleries)
 
             case .fetchMoreGalleriesDone(let result):
                 state.footerLoadingState = .idle

--- a/EhPanda/View/Detail/Previews/PreviewsReducer.swift
+++ b/EhPanda/View/Detail/Previews/PreviewsReducer.swift
@@ -111,8 +111,11 @@ struct PreviewsReducer: Reducer {
                 else { return .none }
                 state.loadingState = .loading
                 let pageNum = state.previewConfig.pageNumber(index: index)
-                return GalleryPreviewURLsRequest(galleryURL: galleryURL, pageNum: pageNum)
-                    .effect.map(Action.fetchPreviewURLsDone).cancellable(id: CancelID.fetchPreviewURLs)
+                return .run { send in
+                    let response = await GalleryPreviewURLsRequest(galleryURL: galleryURL, pageNum: pageNum).response()
+                    await send(Action.fetchPreviewURLsDone(response))
+                }
+                .cancellable(id: CancelID.fetchPreviewURLs)
 
             case .fetchPreviewURLsDone(let result):
                 state.loadingState = .idle

--- a/EhPanda/View/Favorites/FavoritesReducer.swift
+++ b/EhPanda/View/Favorites/FavoritesReducer.swift
@@ -113,10 +113,12 @@ struct FavoritesReducer: Reducer {
                 } else {
                     state.rawPageNumber[state.index]?.resetPages()
                 }
-                return FavoritesGalleriesRequest(
-                    favIndex: state.index, keyword: state.keyword, sortOrder: sortOrder
-                )
-                .effect.map { [index = state.index] result in Action.fetchGalleriesDone(index, result) }
+                return .run { [state] send in
+                    let response = await FavoritesGalleriesRequest(
+                        favIndex: state.index, keyword: state.keyword, sortOrder: sortOrder
+                    ).response()
+                    await send(Action.fetchGalleriesDone(state.index, response))
+                }
 
             case .fetchGalleriesDone(let targetFavIndex, let result):
                 state.rawLoadingState[targetFavIndex] = .idle
@@ -146,13 +148,15 @@ struct FavoritesReducer: Reducer {
                       let lastItemTimestamp = pageNumber.lastItemTimestamp
                 else { return .none }
                 state.rawFooterLoadingState[state.index] = .loading
-                return MoreFavoritesGalleriesRequest(
-                    favIndex: state.index,
-                    lastID: lastID,
-                    lastTimestamp: lastItemTimestamp,
-                    keyword: state.keyword
-                )
-                .effect.map { [index = state.index] result in Action.fetchMoreGalleriesDone(index, result) }
+                return .run { [state] send in
+                    let response = await MoreFavoritesGalleriesRequest(
+                        favIndex: state.index,
+                        lastID: lastID,
+                        lastTimestamp: lastItemTimestamp,
+                        keyword: state.keyword
+                    ).response()
+                    await send(Action.fetchMoreGalleriesDone(state.index, response))
+                }
 
             case .fetchMoreGalleriesDone(let targetFavIndex, let result):
                 state.rawFooterLoadingState[targetFavIndex] = .idle

--- a/EhPanda/View/Home/Frontpage/FrontpageReducer.swift
+++ b/EhPanda/View/Home/Frontpage/FrontpageReducer.swift
@@ -92,9 +92,11 @@ struct FrontpageReducer: Reducer {
                 state.loadingState = .loading
                 state.pageNumber.resetPages()
                 let filter = databaseClient.fetchFilterSynchronously(range: .global)
-                return FrontpageGalleriesRequest(filter: filter).effect
-                    .map(Action.fetchGalleriesDone)
-                    .cancellable(id: CancelID.fetchGalleries)
+                return .run { send in
+                    let response = await FrontpageGalleriesRequest(filter: filter).response()
+                    await send(Action.fetchGalleriesDone(response))
+                }
+                .cancellable(id: CancelID.fetchGalleries)
 
             case .fetchGalleriesDone(let result):
                 state.loadingState = .idle
@@ -123,9 +125,11 @@ struct FrontpageReducer: Reducer {
                 else { return .none }
                 state.footerLoadingState = .loading
                 let filter = databaseClient.fetchFilterSynchronously(range: .global)
-                return MoreFrontpageGalleriesRequest(filter: filter, lastID: lastID).effect
-                    .map(Action.fetchMoreGalleriesDone)
-                    .cancellable(id: CancelID.fetchMoreGalleries)
+                return .run { send in
+                    let response = await MoreFrontpageGalleriesRequest(filter: filter, lastID: lastID).response()
+                    await send(Action.fetchMoreGalleriesDone(response))
+                }
+                .cancellable(id: CancelID.fetchMoreGalleries)
 
             case .fetchMoreGalleriesDone(let result):
                 state.footerLoadingState = .idle

--- a/EhPanda/View/Home/HomeReducer.swift
+++ b/EhPanda/View/Home/HomeReducer.swift
@@ -155,8 +155,10 @@ struct HomeReducer: Reducer {
                 state.popularLoadingState = .loading
                 state.rawCardColors = [String: [Color]]()
                 let filter = databaseClient.fetchFilterSynchronously(range: .global)
-                return PopularGalleriesRequest(filter: filter)
-                    .effect.map(Action.fetchPopularGalleriesDone)
+                return .run { send in
+                    let response = await PopularGalleriesRequest(filter: filter).response()
+                    await send(Action.fetchPopularGalleriesDone(response))
+                }
 
             case .fetchPopularGalleriesDone(let result):
                 state.popularLoadingState = .idle
@@ -179,8 +181,10 @@ struct HomeReducer: Reducer {
                 guard state.frontpageLoadingState != .loading else { return .none }
                 state.frontpageLoadingState = .loading
                 let filter = databaseClient.fetchFilterSynchronously(range: .global)
-                return FrontpageGalleriesRequest(filter: filter)
-                    .effect.map(Action.fetchFrontpageGalleriesDone)
+                return .run { send in
+                    let response = await FrontpageGalleriesRequest(filter: filter).response()
+                    await send(Action.fetchFrontpageGalleriesDone(response))
+                }
 
             case .fetchFrontpageGalleriesDone(let result):
                 state.frontpageLoadingState = .idle
@@ -202,8 +206,10 @@ struct HomeReducer: Reducer {
             case .fetchToplistsGalleries(let index, let pageNum):
                 guard state.toplistsLoadingState[index] != .loading else { return .none }
                 state.toplistsLoadingState[index] = .loading
-                return ToplistsGalleriesRequest(catIndex: index, pageNum: pageNum)
-                    .effect.map({ Action.fetchToplistsGalleriesDone(index, $0) })
+                return .run { send in
+                    let response = await ToplistsGalleriesRequest(catIndex: index, pageNum: pageNum).response()
+                    await send(Action.fetchToplistsGalleriesDone(index, response))
+                }
 
             case .fetchToplistsGalleriesDone(let index, let result):
                 state.toplistsLoadingState[index] = .idle

--- a/EhPanda/View/Home/Popular/PopularReducer.swift
+++ b/EhPanda/View/Home/Popular/PopularReducer.swift
@@ -79,8 +79,11 @@ struct PopularReducer: Reducer {
                 guard state.loadingState != .loading else { return .none }
                 state.loadingState = .loading
                 let filter = databaseClient.fetchFilterSynchronously(range: .global)
-                return PopularGalleriesRequest(filter: filter)
-                    .effect.map(Action.fetchGalleriesDone).cancellable(id: CancelID.fetchGalleries)
+                return .run { send in
+                    let response = await PopularGalleriesRequest(filter: filter).response()
+                    await send(Action.fetchGalleriesDone(response))
+                }
+                .cancellable(id: CancelID.fetchGalleries)
 
             case .fetchGalleriesDone(let result):
                 state.loadingState = .idle

--- a/EhPanda/View/Home/Toplists/ToplistsReducer.swift
+++ b/EhPanda/View/Home/Toplists/ToplistsReducer.swift
@@ -146,9 +146,11 @@ struct ToplistsReducer: Reducer {
                 } else {
                     state.rawPageNumber[state.type]?.resetPages()
                 }
-                return ToplistsGalleriesRequest(catIndex: state.type.categoryIndex, pageNum: pageNum)
-                    .effect.map({ [type = state.type] in Action.fetchGalleriesDone(type, $0) })
-                    .cancellable(id: CancelID.fetchGalleries)
+                return .run { [type = state.type] send in
+                    let response = await ToplistsGalleriesRequest(catIndex: type.categoryIndex, pageNum: pageNum).response()
+                    await send(Action.fetchGalleriesDone(type, response))
+                }
+                .cancellable(id: CancelID.fetchGalleries)
 
             case .fetchGalleriesDone(let type, let result):
                 state.rawLoadingState[type] = .idle
@@ -176,9 +178,11 @@ struct ToplistsReducer: Reducer {
                 else { return .none }
                 state.rawFooterLoadingState[state.type] = .loading
                 let pageNum = pageNumber.current + 1
-                return MoreToplistsGalleriesRequest(catIndex: state.type.categoryIndex, pageNum: pageNum)
-                    .effect.map({ [type = state.type] in Action.fetchMoreGalleriesDone(type, $0) })
-                    .cancellable(id: CancelID.fetchMoreGalleries)
+                return .run { [type = state.type] send in
+                    let response = await MoreToplistsGalleriesRequest(catIndex: type.categoryIndex, pageNum: pageNum).response()
+                    await send(Action.fetchMoreGalleriesDone(type, response))
+                }
+                .cancellable(id: CancelID.fetchMoreGalleries)
 
             case .fetchMoreGalleriesDone(let type, let result):
                 state.rawFooterLoadingState[type] = .idle

--- a/EhPanda/View/Setting/EhSetting/EhSettingReducer.swift
+++ b/EhPanda/View/Setting/EhSetting/EhSettingReducer.swift
@@ -84,8 +84,11 @@ struct EhSettingReducer: Reducer {
             case .fetchEhSetting:
                 guard state.loadingState != .loading else { return .none }
                 state.loadingState = .loading
-                return EhSettingRequest().effect.map(Action.fetchEhSettingDone)
-                    .cancellable(id: CancelID.fetchEhSetting)
+                return .run { send in
+                    let response = await EhSettingRequest().response()
+                    await send(Action.fetchEhSettingDone(response))
+                }
+                .cancellable(id: CancelID.fetchEhSetting)
 
             case .fetchEhSettingDone(let result):
                 state.loadingState = .idle
@@ -104,8 +107,11 @@ struct EhSettingReducer: Reducer {
                 else { return .none }
 
                 state.submittingState = .loading
-                return SubmitEhSettingChangesRequest(ehSetting: ehSetting)
-                    .effect.map(Action.submitChangesDone).cancellable(id: CancelID.submitChanges)
+                return .run { send in
+                    let response = await SubmitEhSettingChangesRequest(ehSetting: ehSetting).response()
+                    await send(Action.submitChangesDone(response))
+                }
+                .cancellable(id: CancelID.submitChanges)
 
             case .submitChangesDone(let result):
                 state.submittingState = .idle
@@ -121,8 +127,11 @@ struct EhSettingReducer: Reducer {
             case .performAction(let action, let name, let set):
                 guard state.submittingState != .loading else { return .none }
                 state.submittingState = .loading
-                return EhProfileRequest(action: action, name: name, set: set)
-                    .effect.map(Action.performActionDone).cancellable(id: CancelID.performAction)
+                return .run { send in
+                    let response = await EhProfileRequest(action: action, name: name, set: set).response()
+                    await send(Action.performActionDone(response))
+                }
+                .cancellable(id: CancelID.performAction)
 
             case .performActionDone(let result):
                 state.submittingState = .idle

--- a/EhPanda/View/Setting/Login/LoginReducer.swift
+++ b/EhPanda/View/Setting/Login/LoginReducer.swift
@@ -73,8 +73,11 @@ struct LoginReducer: Reducer {
                     .run { _ in
                         hapticsClient.generateFeedback(.soft)
                     },
-                    LoginRequest(username: state.username, password: state.password)
-                        .effect.map(Action.loginDone).cancellable(id: CancelID.login)
+                    .run { [state] send in
+                        let response = await LoginRequest(username: state.username, password: state.password).response()
+                        await send(Action.loginDone(response))
+                    }
+                    .cancellable(id: CancelID.login)
                 )
 
             case .loginDone(let result):


### PR DESCRIPTION
In this pr:
- Fixed the final warning for `Request.publisher` to `Effect`
- Update TCA to 1.0.0
- Fix nested binding bug

I think the ideal fix is to change the model of `Request` from publisher to async function, because request should only be evaluated once, but this is not practical to do in one pr.
I found a useful snippet from [this artical](https://medium.com/geekculture/from-combine-to-async-await-c08bf1d15b77), which transform a publisher to an async throwing function. I modified this snippet to non-throwing and use a typed error.

---

I found the nested binding was broken in my earlier pr. There is a [suggested fix](https://github.com/pointfreeco/swift-composable-architecture/pull/2226) from version 0.55.0 to use `Reducer.onChange`
