### PR TITLE
add image request timeout config

### DIFF
--- a/EhPanda/App/Tools/Defaults.swift
+++ b/EhPanda/App/Tools/Defaults.swift
@@ -65,6 +65,21 @@ struct Defaults {
     struct Regex {
         static let tagSuggestion: NSRegularExpression? = try? .init(pattern: "(\\S+:\".+?\"|\".+?\"|\\S+:\\S+|\\S+)")
     }
+    struct Network {
+        /// 普通请求超时时间（秒）
+        static let normalRequestTimeout: TimeInterval = 30.0
+        /// 普通请求资源超时时间（秒）
+        static let normalResourceTimeout: TimeInterval = 60.0
+        
+        /// 图片请求超时时间（秒）
+        static let imageRequestTimeout: TimeInterval = 60.0
+        /// 图片请求资源超时时间（秒）
+        static let imageResourceTimeout: TimeInterval = 120.0
+        
+        /// 重试次数
+        static let retryCount: Int = 3
+    }
+    
     struct URL {
         static var host: Foundation.URL { AppUtil.galleryHost == .exhentai ? exhentai : ehentai }
         static let ehentai: Foundation.URL = .init(string: "https://e-hentai.org/").forceUnwrapped

--- a/EhPanda/Network/DFExtensions.swift
+++ b/EhPanda/Network/DFExtensions.swift
@@ -62,6 +62,40 @@ extension URLSessionConfiguration {
         config.protocolClasses = [DFURLProtocol.self]
         return config
     }
+    
+    /// 为普通请求配置的URLSession
+    static var normalRequest: URLSessionConfiguration {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = Defaults.Network.normalRequestTimeout
+        config.timeoutIntervalForResource = Defaults.Network.normalResourceTimeout
+        return config
+    }
+    
+    /// 为图片请求配置的URLSession
+    static var imageRequest: URLSessionConfiguration {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = Defaults.Network.imageRequestTimeout
+        config.timeoutIntervalForResource = Defaults.Network.imageResourceTimeout
+        return config
+    }
+    
+    #if DEBUG
+    /// 验证网络配置的调试方法
+    static func validateNetworkConfiguration() {
+        print("=== 网络配置验证 ===")
+        
+        let normalConfig = URLSessionConfiguration.normalRequest
+        print("普通请求超时: \(normalConfig.timeoutIntervalForRequest)秒")
+        print("普通资源超时: \(normalConfig.timeoutIntervalForResource)秒")
+        
+        let imageConfig = URLSessionConfiguration.imageRequest
+        print("图片请求超时: \(imageConfig.timeoutIntervalForRequest)秒")
+        print("图片资源超时: \(imageConfig.timeoutIntervalForResource)秒")
+        
+        print("重试次数: \(Defaults.Network.retryCount)次")
+        print("=== 配置验证完成 ===")
+    }
+    #endif
 }
 
 // MARK: CFHTTPMessage


### PR DESCRIPTION
Loading large images often times out. Add timeout handling for image requests.